### PR TITLE
fix!: updates to path mapping

### DIFF
--- a/src/openjd/sessions/__init__.py
+++ b/src/openjd/sessions/__init__.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from ._logging import LOG
-from ._path_mapping import PathMappingOS, PathMappingRule
+from ._path_mapping import PathFormat, PathMappingRule
 from ._session import ActionStatus, Session, SessionCallbackType, SessionState
 from ._session_user import PosixSessionUser, SessionUser
 from ._types import (
@@ -23,7 +23,7 @@ __all__ = (
     "LOG",
     "Parameter",
     "ParameterType",
-    "PathMappingOS",
+    "PathFormat",
     "PathMappingRule",
     "PosixSessionUser",
     "Session",

--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -777,24 +777,21 @@ class Session(object):
         """Materialize path mapping rules to disk and the os environment variables."""
         if self._path_mapping_rules:
             rules_dict = {
+                "version": "pathmapping-1.0",
                 "path_mapping_rules": [
                     {
-                        "source_os": rule.source_os.value,
+                        "source_path_format": rule.source_path_format.value,
                         "source_path": str(rule.source_path),
                         "destination_path": str(rule.destination_path),
                     }
                     for rule in self._path_mapping_rules
-                ]
+                ],
             }
             symtab[ValueReferenceConstants_2023_09.HAS_PATH_MAPPING_RULES.value] = "true"
         else:
             rules_dict = dict()
             symtab[ValueReferenceConstants_2023_09.HAS_PATH_MAPPING_RULES.value] = "false"
         rules_json = json.dumps(rules_dict)
-        # TODO - Remove this environment variable before the formal release of the lib/spec.
-        #  Reason: This is an interim workaround for functionality that was missing.
-        os_env["PATH_MAPPING_RULES"] = rules_json
-        # TODO /stop
         file_handle, filename = mkstemp(dir=self.working_directory, suffix=".json", text=True)
         os.close(file_handle)
         write_file_for_user(Path(filename), rules_json, self._user)

--- a/test/openjd/sessions/test_path_mapping.py
+++ b/test/openjd/sessions/test_path_mapping.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from openjd.sessions import PathMappingOS, PathMappingRule
+from openjd.sessions import PathFormat, PathMappingRule
 from openjd.sessions import _path_mapping as path_mapping_impl_mod
 
 
@@ -21,7 +21,7 @@ class TestPathMapping:
         [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.POSIX,
+                    source_path_format=PathFormat.POSIX,
                     source_path=PurePosixPath("/mnt/shared/"),
                     destination_path=PurePosixPath("/newprefix"),
                 ),
@@ -52,7 +52,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.POSIX,
+                    source_path_format=PathFormat.POSIX,
                     source_path=PurePosixPath("/mnt/shared/"),
                     destination_path=PureWindowsPath("c:\\newprefix"),
                 ),
@@ -91,7 +91,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("c:\\mnt\\shared\\"),
                     destination_path=PurePosixPath("/newprefix"),
                 ),
@@ -130,7 +130,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("c:\\mnt\\shared\\"),
                     destination_path=PureWindowsPath("c:\\newprefix"),
                 ),
@@ -173,7 +173,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("\\\\128.0.0.1\\share\\assets"),
                     destination_path=PureWindowsPath("z:\\assets"),
                 ),
@@ -198,7 +198,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("z:\\assets"),
                     destination_path=PureWindowsPath("\\\\128.0.0.1\\share\\assets"),
                 ),
@@ -223,7 +223,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("\\\\.\\c:\\assets"),
                     destination_path=PureWindowsPath("z:\\assets"),
                 ),
@@ -248,7 +248,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("z:\\assets"),
                     destination_path=PureWindowsPath("\\\\.\\c:\\assets"),
                 ),
@@ -273,7 +273,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("\\\\?\\c:\\assets"),
                     destination_path=PureWindowsPath("z:\\assets"),
                 ),
@@ -298,7 +298,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("z:\\assets"),
                     destination_path=PureWindowsPath("\\\\?\\c:\\assets"),
                 ),
@@ -323,7 +323,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath(
                         "\\\\?\\Volume{b75e2c83-0000-0000-0000-602f12345678}\\assets"
                     ),
@@ -350,7 +350,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("z:\\assets"),
                     destination_path=PureWindowsPath(
                         "\\\\?\\Volume{b75e2c83-0000-0000-0000-602f12345678}\\assets"
@@ -393,7 +393,7 @@ class TestPathMapping:
         [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.POSIX,
+                    source_path_format=PathFormat.POSIX,
                     source_path=PurePosixPath("/mnt/shared"),
                     destination_path=PureWindowsPath("c:\\newprefix"),
                 ),
@@ -409,7 +409,7 @@ class TestPathMapping:
         + [
             pytest.param(
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("c:\\mnt\\shared\\"),
                     destination_path=PureWindowsPath("c:\\newprefix"),
                 ),
@@ -437,18 +437,18 @@ class TestPathMapping:
         "rule_params",
         [
             {
-                "source_os": PathMappingOS.WINDOWS,
+                "source_path_format": PathFormat.WINDOWS,
                 "source_path": PurePosixPath("C:\\oldprefix"),
                 "destination_path": PureWindowsPath("c:\\newprefix"),
             },
             {
-                "source_os": PathMappingOS.POSIX,
+                "source_path_format": PathFormat.POSIX,
                 "source_path": PureWindowsPath("/mnt/oldprefix"),
                 "destination_path": PureWindowsPath("c:\\newprefix"),
             },
         ],
     )
-    def test_mismatching_source_os_path(self, rule_params):
+    def test_mismatching_source_path_format_path(self, rule_params):
         with pytest.raises(ValueError):
             PathMappingRule(**rule_params)
 
@@ -457,48 +457,48 @@ class TestPathMapping:
         [
             (
                 {
-                    "source_os": "WINDOWS",
+                    "source_path_format": "WINDOWS",
                     "source_path": "C:\\oldprefix",
                     "destination_path": "c:\\newprefix",
                 },
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("C:\\oldprefix"),
                     destination_path=PurePath("c:\\newprefix"),
                 ),
             ),
             (
                 {
-                    "source_os": "POSIX",
+                    "source_path_format": "POSIX",
                     "source_path": "/mnt/oldprefix",
                     "destination_path": "c:\\newprefix",
                 },
                 PathMappingRule(
-                    source_os=PathMappingOS.POSIX,
+                    source_path_format=PathFormat.POSIX,
                     source_path=PurePosixPath("/mnt/oldprefix"),
                     destination_path=PurePath("c:\\newprefix"),
                 ),
             ),
             (
                 {
-                    "source_os": "windows",
+                    "source_path_format": "windows",
                     "source_path": "C:\\oldprefix",
                     "destination_path": "c:\\newprefix",
                 },
                 PathMappingRule(
-                    source_os=PathMappingOS.WINDOWS,
+                    source_path_format=PathFormat.WINDOWS,
                     source_path=PureWindowsPath("C:\\oldprefix"),
                     destination_path=PurePath("c:\\newprefix"),
                 ),
             ),
             (
                 {
-                    "source_os": "posix",
+                    "source_path_format": "posix",
                     "source_path": "/mnt/oldprefix",
                     "destination_path": "c:\\newprefix",
                 },
                 PathMappingRule(
-                    source_os=PathMappingOS.POSIX,
+                    source_path_format=PathFormat.POSIX,
                     source_path=PurePosixPath("/mnt/oldprefix"),
                     destination_path=PurePath("c:\\newprefix"),
                 ),
@@ -514,17 +514,17 @@ class TestPathMapping:
         [
             (
                 {
-                    "source_os": "WINDOWS10",
+                    "source_path_format": "WINDOWS10",
                     "source_path": "C:\\oldprefix",
                     "destination_path": "c:\\newprefix",
                 }
             ),
             ({"source_path": "/mnt/oldprefix", "destination_path": "c:\\newprefix"}),
-            ({"source_os": "POSIX", "destination_path": "c:\\newprefix"}),
-            ({"source_os": "POSIX", "source_path": "/mnt/oldprefix"}),
+            ({"source_path_format": "POSIX", "destination_path": "c:\\newprefix"}),
+            ({"source_path_format": "POSIX", "source_path": "/mnt/oldprefix"}),
             (
                 {
-                    "source_os": "windows",
+                    "source_path_format": "windows",
                     "source_path": "C:\\oldprefix",
                     "destination_path": "c:\\newprefix",
                     "extra_field": "value",

--- a/test/openjd/sessions/test_session.py
+++ b/test/openjd/sessions/test_session.py
@@ -39,7 +39,7 @@ from openjd.sessions import (
     ActionStatus,
     Parameter,
     ParameterType,
-    PathMappingOS,
+    PathFormat,
     PathMappingRule,
     Session,
     SessionState,
@@ -644,9 +644,7 @@ class TestSessionRunTask_2023_09:  # noqa: N801
             # THEN
             assert session._runner is not None
             assert fix_foo_baz_environment.variables is not None
-            assert session._runner._os_env_vars == dict(
-                fix_foo_baz_environment.variables, **{"PATH_MAPPING_RULES": "{}"}
-            )
+            assert session._runner._os_env_vars == dict(fix_foo_baz_environment.variables)
 
 
 class TestSessionCancel:
@@ -1005,7 +1003,7 @@ class TestSessionEnterEnvironment_2023_09:  # noqa: N801
                 time.sleep(0.1)
             assert session.state == SessionState.READY
             assert session._runner is not None
-            assert session._runner._os_env_vars == dict(variables, **{"PATH_MAPPING_RULES": "{}"})
+            assert session._runner._os_env_vars == dict(variables)
 
     @pytest.mark.usefixtures("caplog")  # builtin fixture
     def test_enter_environment_with_resolved_variables(
@@ -1066,7 +1064,7 @@ class TestSessionEnterEnvironment_2023_09:  # noqa: N801
                 time.sleep(0.1)
 
             assert session._runner is not None
-            assert session._runner._os_env_vars == dict(variables2, **{"PATH_MAPPING_RULES": "{}"})
+            assert session._runner._os_env_vars == dict(variables2)
 
 
 class TestSessionExitEnvironment_2023_09:  # noqa: N801
@@ -1282,7 +1280,7 @@ class TestSessionExitEnvironment_2023_09:  # noqa: N801
             # THEN
             assert session.state == SessionState.READY_ENDING
             assert session._runner is not None
-            assert session._runner._os_env_vars == dict(variables, **{"PATH_MAPPING_RULES": "{}"})
+            assert session._runner._os_env_vars == dict(variables)
 
     def test_exit_two_environments_with_variables(self) -> None:
         # GIVEN
@@ -1313,7 +1311,7 @@ class TestSessionExitEnvironment_2023_09:  # noqa: N801
             # THEN
             assert session.state == SessionState.READY_ENDING
             assert session._runner is not None
-            assert session._runner._os_env_vars == dict(variables2, **{"PATH_MAPPING_RULES": "{}"})
+            assert session._runner._os_env_vars == dict(variables2)
 
             session.exit_environment(identifier=identifier1)
             # Wait for the process to exit
@@ -1323,7 +1321,7 @@ class TestSessionExitEnvironment_2023_09:  # noqa: N801
             # THEN
             assert session.state == SessionState.READY_ENDING
             assert session._runner is not None
-            assert session._runner._os_env_vars == dict(variables1, **{"PATH_MAPPING_RULES": "{}"})
+            assert session._runner._os_env_vars == dict(variables1)
 
 
 class TestPathMapping_v2023_09:  # noqa: N801
@@ -1337,20 +1335,21 @@ class TestPathMapping_v2023_09:  # noqa: N801
             pytest.param(
                 [
                     PathMappingRule(
-                        source_os=PathMappingOS.POSIX,
+                        source_path_format=PathFormat.POSIX,
                         source_path=PurePosixPath("/home/user"),
                         destination_path=PurePosixPath("/mnt/share/user"),
                     ),
                 ],
                 json.dumps(
                     {
+                        "version": "pathmapping-1.0",
                         "path_mapping_rules": [
                             {
-                                "source_os": "POSIX",
+                                "source_path_format": "POSIX",
                                 "source_path": "/home/user",
                                 "destination_path": "/mnt/share/user",
                             }
-                        ]
+                        ],
                     }
                 ),
                 id="single posix",
@@ -1358,20 +1357,21 @@ class TestPathMapping_v2023_09:  # noqa: N801
             pytest.param(
                 [
                     PathMappingRule(
-                        source_os=PathMappingOS.WINDOWS,
+                        source_path_format=PathFormat.WINDOWS,
                         source_path=PureWindowsPath(r"c:\Users\user"),
                         destination_path=PurePosixPath("/mnt/share/user"),
                     ),
                 ],
                 json.dumps(
                     {
+                        "version": "pathmapping-1.0",
                         "path_mapping_rules": [
                             {
-                                "source_os": "WINDOWS",
+                                "source_path_format": "WINDOWS",
                                 "source_path": r"c:\Users\user",
                                 "destination_path": "/mnt/share/user",
                             }
-                        ]
+                        ],
                     }
                 ),
                 id="single windows",
@@ -1379,30 +1379,31 @@ class TestPathMapping_v2023_09:  # noqa: N801
             pytest.param(
                 [
                     PathMappingRule(
-                        source_os=PathMappingOS.POSIX,
+                        source_path_format=PathFormat.POSIX,
                         source_path=PurePosixPath("/home/user"),
                         destination_path=PurePosixPath("/mnt/share/user"),
                     ),
                     PathMappingRule(
-                        source_os=PathMappingOS.POSIX,
+                        source_path_format=PathFormat.POSIX,
                         source_path=PurePosixPath("/home/user2"),
                         destination_path=PurePosixPath("/mnt/share/user2"),
                     ),
                 ],
                 json.dumps(
                     {
+                        "version": "pathmapping-1.0",
                         "path_mapping_rules": [
                             {
-                                "source_os": "POSIX",
+                                "source_path_format": "POSIX",
                                 "source_path": "/home/user",
                                 "destination_path": "/mnt/share/user",
                             },
                             {
-                                "source_os": "POSIX",
+                                "source_path_format": "POSIX",
                                 "source_path": "/home/user2",
                                 "destination_path": "/mnt/share/user2",
                             },
-                        ]
+                        ],
                     }
                 ),
                 id="multiple posix",
@@ -1410,30 +1411,31 @@ class TestPathMapping_v2023_09:  # noqa: N801
             pytest.param(
                 [
                     PathMappingRule(
-                        source_os=PathMappingOS.WINDOWS,
+                        source_path_format=PathFormat.WINDOWS,
                         source_path=PureWindowsPath(r"c:\Users\user"),
                         destination_path=PurePosixPath("/mnt/share/user"),
                     ),
                     PathMappingRule(
-                        source_os=PathMappingOS.WINDOWS,
+                        source_path_format=PathFormat.WINDOWS,
                         source_path=PureWindowsPath(r"c:\Users\user2"),
                         destination_path=PurePosixPath("/mnt/share/user2"),
                     ),
                 ],
                 json.dumps(
                     {
+                        "version": "pathmapping-1.0",
                         "path_mapping_rules": [
                             {
-                                "source_os": "WINDOWS",
+                                "source_path_format": "WINDOWS",
                                 "source_path": r"c:\Users\user",
                                 "destination_path": "/mnt/share/user",
                             },
                             {
-                                "source_os": "WINDOWS",
+                                "source_path_format": "WINDOWS",
                                 "source_path": r"c:\Users\user2",
                                 "destination_path": "/mnt/share/user2",
                             },
-                        ]
+                        ],
                     }
                 ),
                 id="multiple windows",
@@ -1456,8 +1458,6 @@ class TestPathMapping_v2023_09:  # noqa: N801
             session._materialize_path_mapping(SchemaVersion.v2023_09, env_vars, symtab)
 
             # THEN
-            assert "PATH_MAPPING_RULES" in env_vars
-            assert env_vars["PATH_MAPPING_RULES"] == expected_json
             assert symtab["Session.HasPathMappingRules"] == ("true" if rules else "false")
             assert "Session.PathMappingRulesFile" in symtab
             filename = symtab["Session.PathMappingRulesFile"]
@@ -1484,7 +1484,7 @@ class TestPathMapping_v2023_09:  # noqa: N801
                 EmbeddedFileText_2023_09(
                     name="Script",
                     type=EmbeddedFileTypes_2023_09.TEXT,
-                    data="import os; print('Has: {{Session.HasPathMappingRules}}'); print('Has Env:', 'yes' if os.environ.get('PATH_MAPPING_RULES') else 'no')",
+                    data="import os; print('Has: {{Session.HasPathMappingRules}}')",
                 )
             ],
         )
@@ -1493,7 +1493,7 @@ class TestPathMapping_v2023_09:  # noqa: N801
         task_params = list[Parameter]()
         path_mapping_rules = [
             PathMappingRule(
-                source_os=PathMappingOS.POSIX,
+                source_path_format=PathFormat.POSIX,
                 source_path=PurePosixPath("/home/user"),
                 destination_path=PurePosixPath("/mnt/share/user"),
             ),
@@ -1510,7 +1510,6 @@ class TestPathMapping_v2023_09:  # noqa: N801
 
             # THEN
             assert "Has: true" in caplog.messages
-            assert "Has Env: yes" in caplog.messages
 
     @pytest.mark.usefixtures("caplog")  # builtin fixture
     def test_enter_environment(self, caplog: pytest.LogCaptureFixture) -> None:
@@ -1531,7 +1530,7 @@ class TestPathMapping_v2023_09:  # noqa: N801
                     EmbeddedFileText_2023_09(
                         name="Script",
                         type=EmbeddedFileTypes_2023_09.TEXT,
-                        data="import os; print('Has: {{Session.HasPathMappingRules}}'); print('Has Env:', 'yes' if os.environ.get('PATH_MAPPING_RULES') else 'no')",
+                        data="import os; print('Has: {{Session.HasPathMappingRules}}')",
                     )
                 ],
             )
@@ -1540,7 +1539,7 @@ class TestPathMapping_v2023_09:  # noqa: N801
         job_params = list[Parameter]()
         path_mapping_rules = [
             PathMappingRule(
-                source_os=PathMappingOS.POSIX,
+                source_path_format=PathFormat.POSIX,
                 source_path=PurePosixPath("/home/user"),
                 destination_path=PurePosixPath("/mnt/share/user"),
             ),
@@ -1557,7 +1556,6 @@ class TestPathMapping_v2023_09:  # noqa: N801
 
             # THEN
             assert "Has: true" in caplog.messages
-            assert "Has Env: yes" in caplog.messages
 
     @pytest.mark.usefixtures("caplog")  # builtin fixture
     def test_exit_environment(self, caplog: pytest.LogCaptureFixture) -> None:
@@ -1578,7 +1576,7 @@ class TestPathMapping_v2023_09:  # noqa: N801
                     EmbeddedFileText_2023_09(
                         name="Script",
                         type=EmbeddedFileTypes_2023_09.TEXT,
-                        data="import os; print('Has: {{Session.HasPathMappingRules}}'); print('Has Env:', 'yes' if os.environ.get('PATH_MAPPING_RULES') else 'no')",
+                        data="import os; print('Has: {{Session.HasPathMappingRules}}')",
                     )
                 ],
             )
@@ -1587,7 +1585,7 @@ class TestPathMapping_v2023_09:  # noqa: N801
         job_params = list[Parameter]()
         path_mapping_rules = [
             PathMappingRule(
-                source_os=PathMappingOS.POSIX,
+                source_path_format=PathFormat.POSIX,
                 source_path=PurePosixPath("/home/user"),
                 destination_path=PurePosixPath("/mnt/share/user"),
             ),
@@ -1606,58 +1604,6 @@ class TestPathMapping_v2023_09:  # noqa: N801
 
             # THEN
             assert "Has: true" in caplog.messages
-            assert "Has Env: yes" in caplog.messages
-
-    @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
-    @pytest.mark.xfail(
-        not has_posix_target_user(),
-        reason="Must be running inside of the sudo_environment testing container.",
-    )
-    @pytest.mark.usefixtures("caplog", "posix_target_user")  # builtin fixture
-    def test_cross_user(
-        self, caplog: pytest.LogCaptureFixture, posix_target_user: PosixSessionUser
-    ) -> None:
-        # Test a cross-user run-task just to make sure that the path mapping environment variable
-        # passes through in the correct format.
-
-        # GIVEN
-        # A script that just prints out some messages indicating that we got the
-        # expected data.
-        script = StepScript_2023_09(
-            actions=StepActions_2023_09(
-                onRun=Action_2023_09(command=sys.executable, args=["{{ Task.File.Script }}"])
-            ),
-            embeddedFiles=[
-                EmbeddedFileText_2023_09(
-                    name="Script",
-                    type=EmbeddedFileTypes_2023_09.TEXT,
-                    data="import os; import json; json.loads(os.environ['PATH_MAPPING_RULES']); print('Success')",
-                )
-            ],
-        )
-        session_id = "some id"
-        job_params = list[Parameter]()
-        task_params = list[Parameter]()
-        path_mapping_rules = [
-            PathMappingRule(
-                source_os=PathMappingOS.POSIX,
-                source_path=PurePosixPath("/home/user"),
-                destination_path=PurePosixPath("/mnt/share/user"),
-            ),
-        ]
-        with Session(
-            session_id=session_id,
-            job_parameter_values=job_params,
-            path_mapping_rules=path_mapping_rules,
-            user=posix_target_user,
-        ) as session:
-            # WHEN
-            session.run_task(step_script=script, task_parameter_values=task_params)
-            while session.state == SessionState.RUNNING:
-                time.sleep(0.1)
-
-            # THEN
-            assert "Success" in caplog.messages
 
     @pytest.mark.parametrize(
         "rules, given, expected",
@@ -1665,7 +1611,7 @@ class TestPathMapping_v2023_09:  # noqa: N801
             pytest.param(
                 [
                     PathMappingRule(
-                        source_os=PathMappingOS.POSIX,
+                        source_path_format=PathFormat.POSIX,
                         source_path=PurePosixPath("/mnt"),
                         destination_path=PurePosixPath("/home"),
                     )
@@ -1677,12 +1623,12 @@ class TestPathMapping_v2023_09:  # noqa: N801
             pytest.param(
                 [
                     PathMappingRule(
-                        source_os=PathMappingOS.POSIX,
+                        source_path_format=PathFormat.POSIX,
                         source_path=PurePosixPath("/mnt"),
                         destination_path=PurePosixPath("/home"),
                     ),
                     PathMappingRule(
-                        source_os=PathMappingOS.POSIX,
+                        source_path_format=PathFormat.POSIX,
                         source_path=PurePosixPath("/mnt/share"),
                         destination_path=PurePosixPath("/share"),
                     ),
@@ -1694,12 +1640,12 @@ class TestPathMapping_v2023_09:  # noqa: N801
             pytest.param(
                 [
                     PathMappingRule(
-                        source_os=PathMappingOS.POSIX,
+                        source_path_format=PathFormat.POSIX,
                         source_path=PurePosixPath("/mnt/share"),
                         destination_path=PurePosixPath("/share"),
                     ),
                     PathMappingRule(
-                        source_os=PathMappingOS.POSIX,
+                        source_path_format=PathFormat.POSIX,
                         source_path=PurePosixPath("/mnt"),
                         destination_path=PurePosixPath("/home"),
                     ),
@@ -1711,12 +1657,12 @@ class TestPathMapping_v2023_09:  # noqa: N801
             pytest.param(
                 [
                     PathMappingRule(
-                        source_os=PathMappingOS.POSIX,
+                        source_path_format=PathFormat.POSIX,
                         source_path=PurePosixPath("/mnt/share"),
                         destination_path=PurePosixPath("/mnt"),
                     ),
                     PathMappingRule(
-                        source_os=PathMappingOS.POSIX,
+                        source_path_format=PathFormat.POSIX,
                         source_path=PurePosixPath("/mnt"),
                         destination_path=PurePosixPath("/home"),
                     ),
@@ -1728,7 +1674,7 @@ class TestPathMapping_v2023_09:  # noqa: N801
             pytest.param(
                 [
                     PathMappingRule(
-                        source_os=PathMappingOS.WINDOWS,
+                        source_path_format=PathFormat.WINDOWS,
                         source_path=PureWindowsPath(r"D:\Assets"),
                         destination_path=PurePosixPath("/tmp/openjd"),
                     ),


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

Two changes related to updates in the spec:
1. The field name `source_os` in a path mapping rule's definition was determined to be somewhat ambiguous in its meaning. So, it is being changed to `source_path_format`.
2. We passed path mapping rules in an environment variable before the introduction of the Session.PathMappingRulesFile value. With the creation of that value for format strings, we deprecated the PATH_MAPPING_RULES environment variable. It is time to delete it.

### What was the solution? (How)

Apply the changes as described.

### What is the impact of this change?

Compatibility with the spec that we are releasing.

### How was this change tested?

This code is heavily unit/integration tested. Tests were updated and are passing.

### Was this change documented?

Yes, in the specification documentation.

### Is this a breaking change?

Yes.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*