### PR TITLE
fix: remove misleading 'rm' error message

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -31,3 +31,6 @@ build = "hatch build"
 
 [envs.codebuild.env-vars]
 PIP_INDEX_URL=""
+
+[envs.container.env-vars]
+

--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -373,7 +373,7 @@ class Session(object):
                     if os_name == "posix":
                         subprocess = LoggingSubprocess(
                             logger=self._logger,
-                            args=["rm", "-rf", str(self.working_directory)],
+                            args=["rm", "-rf", f"{str(self.working_directory)}/*"],
                             user=self._user,
                         )
                         # Note: Blocking call until the process has exited

--- a/testing_containers/ldap_sudo_environment/run_tests.sh
+++ b/testing_containers/ldap_sudo_environment/run_tests.sh
@@ -11,5 +11,5 @@ cd code
 python -m venv .venv
 source .venv/bin/activate
 pip install hatch
-# Use the codebuild env so that PIP_INDEX_URL isn't set in the hatch config files.
-hatch run codebuild:test
+# Use the container env so that PIP_INDEX_URL isn't set in the hatch config files.
+hatch run container:test

--- a/testing_containers/localuser_sudo_environment/run_tests.sh
+++ b/testing_containers/localuser_sudo_environment/run_tests.sh
@@ -11,5 +11,5 @@ cd code
 python -m venv .venv
 source .venv/bin/activate
 pip install hatch
-# Use the codebuild env so that PIP_INDEX_URL isn't set in the hatch config files.
-hatch run codebuild:test
+# Use the container env so that PIP_INDEX_URL isn't set in the hatch config files.
+hatch run container:test


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

 When running a Session as a different user on posix systems you will
see a benign, but misleading, error message in the log that looks like:
```
rm: cannot remove '/tmp/openjd/session-name': Permission denied
```

This is caused by our two-phase cleanup of the Session working directory. We start with a cross-user 'rm -rf' to delete everything in the directory, and then do a same-user recursive delete. So, the working directory is getting cleaned up but there is this error in logs that is misleading.

### What was the solution? (How)

 The `rm -rf` just needs to be changed to `rm -rf <dir>/*` from `rm -rf <dir>`.

### What is the impact of this change?

Less confusion. This is a good thing.

### How was this change tested?

I used the testing container. Log:
```
hostuser@7b77d20a3687:/tmp$ mkdir dir1
hostuser@7b77d20a3687:/tmp$ mkdir dir2
hostuser@7b77d20a3687:/tmp$ chgrp sharedgroup dir1 dir2
hostuser@7b77d20a3687:/tmp$ chmod g+w dir1 dir2
hostuser@7b77d20a3687:/tmp$ sudo -u targetuser touch /tmp/dir1/file /tmp/dir2/file
hostuser@7b77d20a3687:/tmp$ sudo -u targetuser rm -rf /tmp/dir1
rm: cannot remove '/tmp/dir1': Operation not permitted
hostuser@7b77d20a3687:/tmp$ sudo -u targetuser rm -rf /tmp/dir2/*
hostuser@7b77d20a3687:/tmp$ ls dir2
```

So, adding the trailing `/*` removes the error message and the contents are still gone.

### Was this change documented?

N/A

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*