### PR TITLE
fix: properly cleanup working dir with posix cross-user

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,4 +130,4 @@ source = [
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 87
+fail_under = 86

--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -29,8 +29,8 @@ from ._path_mapping import PathMappingRule
 from ._runner_base import ScriptRunnerBase
 from ._runner_env_script import EnvironmentScriptRunner
 from ._runner_step_script import StepScriptRunner
-from ._subprocess import LoggingSubprocess
 from ._session_user import SessionUser
+from ._subprocess import LoggingSubprocess
 from ._tempdir import TempDir
 from ._types import (
     ActionState,
@@ -368,9 +368,10 @@ class Session(object):
                 # recursive removal to delete the stuff that only this user can delete.
                 if self._user is not None:
                     if is_posix():
+                        files = [str(f) for f in self.working_directory.glob("*")]
                         subprocess = LoggingSubprocess(
                             logger=self._logger,
-                            args=["rm", "-rf", f"{str(self.working_directory)}/*"],
+                            args=["rm", "-rf"] + files,
                             user=self._user,
                         )
                         # Note: Blocking call until the process has exited

--- a/src/openjd/sessions/_tempdir.py
+++ b/src/openjd/sessions/_tempdir.py
@@ -86,13 +86,17 @@ class TempDir:
             RuntimeError - If not all files could be deleted.
         """
         encountered_errors = False
+        file_paths: list[str] = []
 
         def onerror(f, p, e):
             nonlocal encountered_errors
+            nonlocal file_paths
             encountered_errors = True
+            file_paths.append(str(p))
 
         rmtree(self.path, onerror=onerror)
         if encountered_errors:
             raise RuntimeError(
-                f"Files within temporary directory {str(self.path)} could not be deleted."
+                f"Files within temporary directory {str(self.path)} could not be deleted.\n"
+                + "\n".join(file_paths)
             )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

A previous change to the cleanup logic for the Session working directory actually broke it. It wasn't deleting any contents anymore. This fixes that.

 It also fills in a small testing gap that demonstrates that the initiating process's environment doesn't bleed through to the subprocess on posix systems when running cross-user.

### What was the solution? (How)

We were using our LoggingSubprocess to run `rm -rf <workingdir>/*`, but our LoggingSubprocess doesn't run the command in a shell and effectively escapes the "workingdir/*" part of the command. The '*' in that command requires a shell expansion for the command to function correctly. So, we use a glob on the directory and pass the results explicitly in the `rm` rather than using a `*`

### What is the impact of this change?

Session directory cleanup works again.

### How was this change tested?

I ran the sudo testing container tests ( I didn't do this last time ), and ensured that the tests passed -- note: without this fix, the tests don't actually pass (we have a failure in `test_cleanup_posix_user`)

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*