### PR TITLE
fix: exporting WindowsSessionUser class

### DIFF
--- a/src/openjd/sessions/__init__.py
+++ b/src/openjd/sessions/__init__.py
@@ -3,7 +3,7 @@
 from ._logging import LOG
 from ._path_mapping import PathFormat, PathMappingRule
 from ._session import ActionStatus, Session, SessionCallbackType, SessionState
-from ._session_user import PosixSessionUser, SessionUser
+from ._session_user import PosixSessionUser, WindowsSessionUser, SessionUser
 from ._types import (
     ActionState,
     EnvironmentIdentifier,
@@ -31,4 +31,5 @@ __all__ = (
     "SessionState",
     "SessionUser",
     "StepScriptModel",
+    "WindowsSessionUser",
 )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The class `WindowsSessionUser` is needed externally. 

### What was the solution? (How)
Export it. 

### What is the impact of this change?
Class will be usable by consumers of Open Job Description. 

### How was this change tested?
Ensured unit tests pass, and built a consumer that uses this class.  

### Was this change documented?
NA

### Is this a breaking change?
No. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*