### PR TITLE
fix: package missing signal subprocess shell script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
 artifacts = [
   "*_version.py",
 ]
-only-packages = true
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `openjd/sessions/_scripts/_posix/_signal_subprocess.sh` script was not being properly packaged in the build sdist and wheel artifacts.

### What was the solution? (How)

Remove the `only-packages = true` setting in the `[tool.hatch.build]` section of `pyproject.toml`. According to [the docs](https://hatch.pypa.io/latest/config/build/#excluding-files-outside-packages):

>   If you want to exclude non-[artifact](https://hatch.pypa.io/latest/config/build/#artifacts) files that do not reside within a Python package, set only-packages to true:

### What is the impact of this change?

The missing shell script which `openjd-sessions-for-python` tries to launch in a sub-process is available when the package is installed from the sdist/wheel artifacts.

### How was this change tested?

1.  Before making the change, ran `hatch clean && hatch build` to empty the `dist` directory and build new artifacts
2.  Ran `tar -tzf dist/*.tar.gz | grep "\.sh"` which produced no output (reproduced issue)
3.  Ran `unzip -l dist/*.whl | grep "\.sh"` which produced no output (reproduced issue)
4.  After making the change, ran `hatch clean && hatch build` to empty the `dist` directory and build new artifacts
2.  Ran `tar -tzf dist/*.tar.gz | grep "\.sh"` which produced:

    ```
    openjd_sessions-0.2.0.post10+g846736a/openjd/sessions/_scripts/_posix/_signal_subprocess.sh
    ```
4.  Ran `unzip -l dist/*.whl | grep "\.sh"` which produced no output (reproduced issue)

    ```
         2195  02-02-2020 00:00   openjd/sessions/_scripts/_posix/_signal_subprocess.sh
    ```

### Was this change documented?

No

### Is this a breaking change?

No, a fixing change :)

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*