### PR TITLE
feat: export package version

### DIFF
--- a/src/openjd/sessions/__init__.py
+++ b/src/openjd/sessions/__init__.py
@@ -13,6 +13,7 @@ from ._types import (
     ParameterType,
     StepScriptModel,
 )
+from ._version import version
 
 __all__ = (
     "ActionState",
@@ -32,4 +33,5 @@ __all__ = (
     "SessionUser",
     "StepScriptModel",
     "WindowsSessionUser",
+    "version",
 )

--- a/test/openjd/test_importable.py
+++ b/test/openjd/test_importable.py
@@ -3,3 +3,11 @@
 
 def test_openjd_importable():
     import openjd  # noqa: F401
+
+
+def test_openjd_session_importable():
+    import openjd.sessions  # noqa: F401
+
+
+def test_version_importable():
+    from openjd.sessions import version  # noqa: F401


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The package version is available in a private symbol, but not a public one. So, consumers cannot query the package version in a safe way.

### What was the solution? (How)

This adds the version value to the public interface of the library.

### What is the impact of this change?

An improved public interface

### How was this change tested?

I added to the unit tests of the package.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*