### PR TITLE
fix: properly delete working dir with Windows impersonation

### DIFF
--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -373,6 +373,7 @@ class Session(object):
                         recursive_delete_cmd = ["rm", "-rf"]
                     else:
                         recursive_delete_cmd = ["Remove-Item", "-Recurse", "-Force"]
+                        files = [", ".join(files)]
 
                     subprocess = LoggingSubprocess(
                         logger=self._logger,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When using impersonation on Windows, `Session.cleanup()` fails with the following error:

```
An unexpected error occurred: A positional parameter cannot be found that accepts argument '-Force'.
```

This is because we create an array of string paths to pass to `Subprocess` to be executed as follows:

```
Remove-Item -Recurse -Force <path1> <path2>
```

This causes powershell to interpret `path1` and `path2` as separate positional parameters, while the [docs](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/remove-item?view=powershell-7.4#-path.) show `Path` should be an array of strings.

### What was the solution? (How)


Convert `files` to an array containing a single array of string paths. This is what gets [passed](https://github.com/xxyggoqtpcmcofkc/openjd-sessions-for-python/blob/a8b7f30c7255eb4ab98244a41a8c1ae1af27d996/src/openjd/sessions/_session.py#L379) to `LoggingSubprocess`:  
```
["Remove-Item", "-Recurse", "-Force", "<path1>, <path2>"]
```

### What is the impact of this change?
`Session.cleanup()` will succeed on Windows when using impersonation

### How was this change tested?
Reproduced bug locally with powershell command. Tested replacement comman d locally.

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*