### PR TITLE
fix: make psutil a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.9"
 dependencies = [
   "openjd-model == 0.1.*",
   "pywin32 == 306; platform_system == 'Windows'",
+  "psutil == 5.9.*; platform_system == 'Windows'",
 ]
 
 [tool.hatch.build]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`psutil` was added as a test dependency but it's used at runtime.

I discovered this when trying to use `openjd-cli`:
```
>openjd --help
Traceback (most recent call last):
  File "C:\Python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\Scripts\openjd.exe\__main__.py", line 4, in <module>
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\lib\site-packages\openjd\__main__.py", line 6, in <module>
    from .cli._create_argparser import create_argparser
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\lib\site-packages\openjd\cli\_create_argparser.py", line 9, in <module>
    from ._run import populate_argparser as populate_run_subparser
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\lib\site-packages\openjd\cli\_run\__init__.py", line 3, in <module>
    from ._run_command import add_run_arguments, do_run
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\lib\site-packages\openjd\cli\_run\_run_command.py", line 9, in <module>
    from ._local_session._session_manager import LocalSession, LogEntry
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\lib\site-packages\openjd\cli\_run\_local_session\_session_manager.py", line 10, in <module>
    from ._actions import EnterEnvironmentAction, ExitEnvironmentAction, RunTaskAction, SessionAction
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\lib\site-packages\openjd\cli\_run\_local_session\_actions.py", line 5, in <module>
    from openjd.sessions import Parameter, Session
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\lib\site-packages\openjd\sessions\__init__.py", line 5, in <module>
    from ._session import ActionStatus, Session, SessionCallbackType, SessionState
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\lib\site-packages\openjd\sessions\_session.py", line 29, in <module>
    from ._runner_base import ScriptRunnerBase
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\lib\site-packages\openjd\sessions\_runner_base.py", line 26, in <module>
    from ._subprocess import LoggingSubprocess
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\lib\site-packages\openjd\sessions\_subprocess.py", line 9, in <module>
    from ._windows_process_killer import kill_windows_process_tree
  File "C:\Users\jericht\.deadline\job_history\jericht\2023-11\2023-11-23-01-Maya-wrench_turntablema\.venv\lib\site-packages\openjd\sessions\_windows_process_killer.py", line 4, in <module>
    from psutil import NoSuchProcess, Process, wait_procs, STATUS_STOPPED
ModuleNotFoundError: No module named 'psutil'
```

### What was the solution? (How)
Add `psutil` to runtime dependencies

### What is the impact of this change?
Consumers work again

### How was this change tested?
N/A

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*