### PR TITLE
fix: parameter name for signal_win_process

### DIFF
--- a/src/openjd/sessions/_scripts/_windows/_signal_win_subprocess.ps1
+++ b/src/openjd/sessions/_scripts/_windows/_signal_win_subprocess.ps1
@@ -1,6 +1,7 @@
-param([Parameter(Mandatory=$true)][int32]$proc_id)
+param([Parameter(Mandatory=$true)][int32]$proc_group_id)
+
 function Send-SIGBREAK {
-    # Geneates a console CTRL_EVENT_BREAK signal to a process group id.
+    # Generates a console CTRL_EVENT_BREAK signal to a process group id.
     param (
         [int]$pgid
     )
@@ -32,6 +33,12 @@ function Send-SIGBREAK {
         }
 "@ -Language CSharp
 
+    $proc = Get-Process -Id $pgid -ErrorAction SilentlyContinue
+    if (-not $proc) {
+        Write-Host "Process $pgid not found"
+        return
+    }
+
     #  Detach from current console
     if (-not [WinConsoleAPIWrapper]::FreeConsole()) {
         Write-Error "ERROR - Failed to free console: $([WinConsoleAPIWrapper]::GetLastErrorMessage())"
@@ -53,4 +60,4 @@ function Send-SIGBREAK {
 }
 
 
-Send-SIGBREAK "$proc_group_id"
+Send-SIGBREAK $proc_group_id


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Missed renaming `proc_id` to `proc_group_id` for the parameter to signal_win_subprocess.ps1 script. 

### What was the solution? (How)
Renamed it.
Also added a quick check the process exists before trying to signal it.

### What is the impact of this change?
Correctly target the process group id (it would have defaulted to 0 otherwise)

### How was this change tested?
`python -m hatch run test`
and manual test of notify with run-as user mode.

### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*