### PR TITLE
feat: modify logging to be easier to understand

### DIFF
--- a/src/openjd/sessions/_embedded_files.py
+++ b/src/openjd/sessions/_embedded_files.py
@@ -132,7 +132,7 @@ class EmbeddedFiles:
             # Add symbols to the symbol table
             for record in records:
                 symtab[record.symbol] = str(record.filename)
-                self._logger.info(f"\tMapping: {record.symbol} -> {record.filename}")
+                self._logger.info(f"Mapping: {record.symbol} -> {record.filename}")
 
             # Write the files to disk.
             for record in records:
@@ -209,4 +209,5 @@ class EmbeddedFiles:
         # Create the file as r/w owner, and optionally group
         write_file_for_user(filename, data, self._user, additional_permissions=execute_permissions)
 
-        self._logger.info(f"\tWrote: {file.name} -> {str(filename)}")
+        self._logger.info(f"Wrote: {file.name} -> {str(filename)}")
+        self._logger.debug("Contents:\n%s", data)

--- a/src/openjd/sessions/_logging.py
+++ b/src/openjd/sessions/_logging.py
@@ -7,3 +7,16 @@ __all__ = "LOG"
 # Name the logger for the sessions module, rather than this specific file
 LOG = logging.getLogger(".".join(__name__.split(".")[:-1]))
 LOG.setLevel(logging.INFO)
+
+
+def log_section_banner(logger: logging.LoggerAdapter, section_title: str) -> None:
+    logger.info("")
+    logger.info("==============================================")
+    logger.info(f"--------- {section_title}")
+    logger.info("==============================================")
+
+
+def log_subsection_banner(logger: logging.LoggerAdapter, section_title: str) -> None:
+    logger.info("----------------------------------------------")
+    logger.info(section_title)
+    logger.info("----------------------------------------------")

--- a/src/openjd/sessions/_runner_base.py
+++ b/src/openjd/sessions/_runner_base.py
@@ -20,6 +20,7 @@ from openjd.model import SymbolTable
 from openjd.model import FormatStringError
 from openjd.model.v2023_09 import Action as Action_2023_09
 from ._embedded_files import EmbeddedFiles, EmbeddedFilesScope, write_file_for_user
+from ._logging import log_subsection_banner
 from ._os_checker import is_posix, is_windows
 from ._powershell_generator import generate_exit_code_wrapper
 from ._session_user import SessionUser
@@ -291,7 +292,7 @@ class ScriptRunnerBase(ABC):
                 user=self._user,
                 additional_permissions=stat.S_IXUSR | stat.S_IXGRP,
             )
-            self._logger.info(f"Wrote the following script to {filename}:\n{script}")
+            self._logger.debug(f"Wrote the following script to {filename}:\n{script}")
 
             subprocess_args = (
                 [filename] if not is_windows() else ["pwsh.exe", "-NonInteractive", filename]
@@ -306,6 +307,7 @@ class ScriptRunnerBase(ABC):
                 self._runtime_limit = Timer(time_limit.total_seconds(), self._on_timelimit)
                 self._runtime_limit.start()
 
+            log_subsection_banner(self._logger, "Phase: Running action")
             self._run_future = self._pool.submit(self._process.run)
         # Intentionally leave the lock section. If the process was *really* fast,
         # then it's possible for the future to have finished before we get to add

--- a/src/openjd/sessions/_runner_env_script.py
+++ b/src/openjd/sessions/_runner_env_script.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from logging import LoggerAdapter
 from pathlib import Path
 from typing import Callable, Optional
@@ -13,8 +13,8 @@ from openjd.model.v2023_09 import (
 )
 from openjd.model.v2023_09 import EnvironmentScript as EnvironmentScript_2023_09
 from ._embedded_files import EmbeddedFilesScope
+from ._logging import log_subsection_banner
 from ._runner_base import (
-    TIME_FORMAT_STR,
     CancelMethod,
     NotifyCancelMethod,
     ScriptRunnerBase,
@@ -105,6 +105,9 @@ class EnvironmentScriptRunner(ScriptRunnerBase):
 
     def _run_env_action(self, action: ActionModel) -> None:
         """Run a specific given action from this Environment."""
+
+        log_subsection_banner(self._logger, "Phase: Setup")
+
         # Write any embedded files to disk
         if (
             self._environment_script is not None
@@ -143,9 +146,6 @@ class EnvironmentScriptRunner(ScriptRunnerBase):
                 self._callback(ActionState.SUCCESS)
             return
 
-        self._logger.info(
-            f"Starting Environment onEnter Action at {datetime.utcnow().strftime(TIME_FORMAT_STR)}"
-        )
         self._run_env_action(self._environment_script.actions.onEnter)
 
     def exit(self) -> None:
@@ -164,9 +164,6 @@ class EnvironmentScriptRunner(ScriptRunnerBase):
                 self._callback(ActionState.SUCCESS)
             return
 
-        self._logger.info(
-            f"Starting Environment onExit Action at {datetime.utcnow().strftime(TIME_FORMAT_STR)}"
-        )
         self._run_env_action(self._environment_script.actions.onExit)
 
     def cancel(self, *, time_limit: Optional[timedelta] = None) -> None:

--- a/src/openjd/sessions/_runner_step_script.py
+++ b/src/openjd/sessions/_runner_step_script.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from logging import LoggerAdapter
 from pathlib import Path
 from typing import Callable, Optional
@@ -12,8 +12,8 @@ from openjd.model.v2023_09 import (
     CancelationMethodNotifyThenTerminate as CancelationMethodNotifyThenTerminate_2023_09,
 )
 from ._embedded_files import EmbeddedFilesScope
+from ._logging import log_subsection_banner
 from ._runner_base import (
-    TIME_FORMAT_STR,
     CancelMethod,
     NotifyCancelMethod,
     ScriptRunnerBase,
@@ -99,11 +99,11 @@ class StepScriptRunner(ScriptRunnerBase):
         """Run the Step Script's onRun Action."""
         if self.state != ScriptRunnerState.READY:
             raise RuntimeError("This cannot be used to run a second subprocess.")
+
+        log_subsection_banner(self._logger, "Phase: Setup")
+
         # For the type checker.
         assert isinstance(self._script, StepScript_2023_09)
-        self._logger.info(
-            f"Starting Task onRun Action at {datetime.utcnow().strftime(TIME_FORMAT_STR)}"
-        )
         # Write any embedded files to disk
         if self._script.embeddedFiles is not None:
             symtab = SymbolTable(source=self._symtab)

--- a/src/openjd/sessions/_subprocess.py
+++ b/src/openjd/sessions/_subprocess.py
@@ -148,11 +148,13 @@ class LoggingSubprocess(object):
             return
 
         self._logger.info(f"Command started as pid: {self._process.pid}")
+        self._logger.info("Output:")
 
         stream = self._process.stdout
         # Convince type checker that stdout is not None
         assert stream is not None
 
+        # Process stdout/stderr of the job; echoing it to our logger
         def _stream_readline_max_length():
             nonlocal stream
             # Enforce a max line length for readline to ensure we don't infinitely grow the buffer
@@ -198,7 +200,7 @@ class LoggingSubprocess(object):
                 self._posix_signal_subprocess(signal="kill", signal_subprocesses=True)
             else:
                 self._logger.info(
-                    f"Start killing the process tree with the root pid: {self._process.pid}"
+                    f"INTERRUPT: Start killing the process tree with the root pid: {self._process.pid}"
                 )
                 kill_windows_process_tree(self._logger, self._process.pid, signal_subprocesses=True)
 
@@ -305,7 +307,7 @@ class LoggingSubprocess(object):
                 str(signal_subprocesses),
             ]
         )
-        self._logger.info(f"Running: {shlex.join(cmd)}")
+        self._logger.info(f"INTERRUPT: Running: {shlex.join(cmd)}")
         result = run(
             cmd,
             stdout=PIPE,
@@ -323,5 +325,5 @@ class LoggingSubprocess(object):
         # Convince the type checker that accessing _process is okay
         assert self._process is not None
 
-        self._logger.info(f"Send CTRL_BREAK_EVENT to {self._process.pid}")
+        self._logger.info(f"INTERRUPT: Sending CTRL_BREAK_EVENT to {self._process.pid}")
         self._process.send_signal(signal.CTRL_BREAK_EVENT)  # type: ignore

--- a/test/openjd/sessions/test_action_filter.py
+++ b/test/openjd/sessions/test_action_filter.py
@@ -101,6 +101,30 @@ class TestActionMonitoringFilter:
                 "foo",
                 id="unset_env, leading whitespace",
             ),
+            pytest.param(
+                "openjd_session_runtime_loglevel: DEBUG",
+                ActionMessageKind.SESSION_RUNTIME_LOGLEVEL,
+                logging.DEBUG,
+                id="loglevel debug",
+            ),
+            pytest.param(
+                "openjd_session_runtime_loglevel: INFO",
+                ActionMessageKind.SESSION_RUNTIME_LOGLEVEL,
+                logging.INFO,
+                id="loglevel debug",
+            ),
+            pytest.param(
+                "openjd_session_runtime_loglevel: WARNING",
+                ActionMessageKind.SESSION_RUNTIME_LOGLEVEL,
+                logging.WARNING,
+                id="loglevel debug",
+            ),
+            pytest.param(
+                "openjd_session_runtime_loglevel: ERROR",
+                ActionMessageKind.SESSION_RUNTIME_LOGLEVEL,
+                logging.ERROR,
+                id="loglevel debug",
+            ),
         ),
     )
     def test_captures_suppress(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The existing session logging is challenging to read in that it:
1. Is a continuous stream of log messages with no deliniation indicating which parts are relevant for which actions.
2. Intermixes the action output with logging from the library; which makes it challenging for the end-user to understand which bits are from which.

### What was the solution? (How)

This commit does some cleanup of the logging to make it easier to read. We now have banners indicating the start of running each action. We also have subbanners indicating what phase of running the action we're in (setup vs running).

As a bonus, I also added a new stdout/stderr handler that will be specific to this implementation of Open Job Description; adding it as-is to the specification would encode Python logging semantics into the spec, and that's not desirable. This new stdout handler provides the end-user a means by which they can dynamically modify the logger log level of this library for the duration of the Session that is being run. This is added as a debugging mechanism so that users can see the contents of files that are materialized to disk, and any other verbose output as added in future. The allowable forms of this handler are: openjd_session_runtime_loglevel: ERROR
openjd_session_runtime_loglevel: WARNING
openjd_session_runtime_loglevel: INFO
openjd_session_runtime_loglevel: DEBUG

i.e. The values of the prefix correspond to Python logger levels.

### What is the impact of this change?

The Session logs should be more understandable by end users.

### How was this change tested?

I did add some unit tests to cover the new stdout handler. Otherwise, I ran the changes via the CLI.

The test template was:
```
specificationVersion: 'jobtemplate-2023-09'
name: Test template
jobEnvironments:
- name: JobEnv
  script:
    embeddedFiles:
    - name: Enter
      type: TEXT
      runnable: true
      data: |
        #!/bin/bash
        echo "openjd_session_runtime_loglevel: DEBUG"
    actions:
      onEnter:
        command: '{{ Env.File.Enter }}'
steps:
- name: Step
  parameterSpace:
    taskParameterDefinitions:
    - name: p1
      type: INT
      range: 1-2
  stepEnvironments:
  - name: StepEnv
    script:
      actions:
        onEnter:
          command: /usr/bin/echo
          args:
          - "Entered"
        onExit:
          command: /usr/bin/echo
          args:
          - "Exited"
  script:
    embeddedFiles:
      - name: runScript
        type: TEXT
        runnable: true
        data: |
          #!/usr/bin/env bash
          echo "{{Task.Param.p1}}"
    actions:
      onRun:
        command: '{{Task.File.runScript}}'
```

With the Job environment in place, we now get output like:
```
$ openjd run test_with_env.yaml --step Step
Fri Dec 22 17:37:39 2023
Fri Dec 22 17:37:39 2023        ==============================================
Fri Dec 22 17:37:39 2023        --------- Entering Environment: JobEnv
Fri Dec 22 17:37:39 2023        ==============================================
Fri Dec 22 17:37:39 2023        ----------------------------------------------
Fri Dec 22 17:37:39 2023        Phase: Setup
Fri Dec 22 17:37:39 2023        ----------------------------------------------
Fri Dec 22 17:37:39 2023        Writing embedded files for Environment to disk.
Fri Dec 22 17:37:39 2023        Mapping: Env.File.Enter -> /tmp/openjd/sample_sessionim30vjpp/embedded_filesxo4qrqkq/tmpj9dkupfd
Fri Dec 22 17:37:39 2023        Wrote: Enter -> /tmp/openjd/sample_sessionim30vjpp/embedded_filesxo4qrqkq/tmpj9dkupfd
Fri Dec 22 17:37:39 2023        ----------------------------------------------
Fri Dec 22 17:37:39 2023        Phase: Running action
Fri Dec 22 17:37:39 2023        ----------------------------------------------
Fri Dec 22 17:37:39 2023        Running command /tmp/openjd/sample_sessionim30vjpp/tmp9vntnpv8.sh
Fri Dec 22 17:37:39 2023        Command started as pid: 927
Fri Dec 22 17:37:39 2023        Output:
Fri Dec 22 17:37:39 2023        openjd_session_runtime_loglevel: DEBUG
Fri Dec 22 17:37:39 2023
Fri Dec 22 17:37:39 2023        ==============================================
Fri Dec 22 17:37:39 2023        --------- Entering Environment: StepEnv
Fri Dec 22 17:37:39 2023        ==============================================
Fri Dec 22 17:37:39 2023        ----------------------------------------------
Fri Dec 22 17:37:39 2023        Phase: Setup
Fri Dec 22 17:37:39 2023        ----------------------------------------------
Fri Dec 22 17:37:39 2023        Wrote the following script to /tmp/openjd/sample_sessionim30vjpp/tmpdel3tq7x.sh:
#!/bin/sh
_term() {
  echo 'Caught SIGTERM'
  test "${CHILD_PID:-}" != "" && echo "Sending SIGTERM to ${CHILD_PID}" && kill -s TERM "${CHILD_PID}"
  wait "${CHILD_PID}"
  exit $?
}
trap _term TERM
cd '/tmp/openjd/sample_sessionim30vjpp'
/usr/bin/echo Entered &
CHILD_PID=$!
wait "$CHILD_PID"
exit $?

Fri Dec 22 17:37:39 2023        ----------------------------------------------
Fri Dec 22 17:37:39 2023        Phase: Running action
Fri Dec 22 17:37:39 2023        ----------------------------------------------
Fri Dec 22 17:37:39 2023        Running command /tmp/openjd/sample_sessionim30vjpp/tmpdel3tq7x.sh
Fri Dec 22 17:37:39 2023        Command started as pid: 930
Fri Dec 22 17:37:39 2023        Output:
Fri Dec 22 17:37:39 2023        Entered
... and so on
```

With the Job Environment commented out, we get:
```
$ openjd run test_with_env.yaml --step Step
Fri Dec 22 17:34:38 2023
Fri Dec 22 17:34:38 2023        ==============================================
Fri Dec 22 17:34:38 2023        --------- Entering Environment: StepEnv
Fri Dec 22 17:34:38 2023        ==============================================
Fri Dec 22 17:34:38 2023        ----------------------------------------------
Fri Dec 22 17:34:38 2023        Phase: Setup
Fri Dec 22 17:34:38 2023        ----------------------------------------------
Fri Dec 22 17:34:38 2023        ----------------------------------------------
Fri Dec 22 17:34:38 2023        Phase: Running action
Fri Dec 22 17:34:38 2023        ----------------------------------------------
Fri Dec 22 17:34:38 2023        Running command /tmp/openjd/sample_sessionnl7wt1su/tmprcjqfc_0.sh
Fri Dec 22 17:34:38 2023        Command started as pid: 30462
Fri Dec 22 17:34:38 2023        Output:
Fri Dec 22 17:34:38 2023        Entered
Fri Dec 22 17:34:38 2023
Fri Dec 22 17:34:38 2023        ==============================================
Fri Dec 22 17:34:38 2023        --------- Running Task
Fri Dec 22 17:34:38 2023        ==============================================
Fri Dec 22 17:34:38 2023        Parameter values:
Fri Dec 22 17:34:38 2023        p1(INT) = 1
Fri Dec 22 17:34:38 2023        ----------------------------------------------
Fri Dec 22 17:34:38 2023        Phase: Setup
Fri Dec 22 17:34:38 2023        ----------------------------------------------
Fri Dec 22 17:34:38 2023        Writing embedded files for Task to disk.
Fri Dec 22 17:34:38 2023        Mapping: Task.File.runScript -> /tmp/openjd/sample_sessionnl7wt1su/embedded_files4v275dh7/tmpdnta7am8
Fri Dec 22 17:34:38 2023        Wrote: runScript -> /tmp/openjd/sample_sessionnl7wt1su/embedded_files4v275dh7/tmpdnta7am8
Fri Dec 22 17:34:38 2023        ----------------------------------------------
Fri Dec 22 17:34:38 2023        Phase: Running action
Fri Dec 22 17:34:38 2023        ----------------------------------------------
Fri Dec 22 17:34:38 2023        Running command /tmp/openjd/sample_sessionnl7wt1su/tmp5hs5hg37.sh
Fri Dec 22 17:34:38 2023        Command started as pid: 30465
Fri Dec 22 17:34:38 2023        Output:
Fri Dec 22 17:34:38 2023        1
Fri Dec 22 17:34:38 2023
... and so on
```

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*