### PR TITLE
feat: Adding manifest folder to session directory

### DIFF
--- a/test/openjd/sessions/test_session.py
+++ b/test/openjd/sessions/test_session.py
@@ -79,6 +79,7 @@ class TestSessionInitialization:
         assert session.state == SessionState.READY
         assert os.path.exists(session.working_directory)
         assert os.path.exists(session.files_directory)
+        assert os.path.exists(session.manifests_directory)
         assert session._session_id == session_id
         assert session._job_parameter_values == job_params
         assert session._job_parameter_values is not job_params
@@ -317,7 +318,10 @@ class TestSessionInitialization:
         assert not os.path.exists(working_dir)
         assert filter not in LOG.filters
 
-    @pytest.mark.parametrize("method", ["_create_working_directory", "_create_files_directory"])
+    @pytest.mark.parametrize(
+        "method",
+        ["_create_working_directory", "_create_files_directory", "_create_manifests_directory"],
+    )
     @pytest.mark.usefixtures("caplog")  # built-in fixture
     def test_failed_directory_create(self, method: str, caplog: pytest.LogCaptureFixture) -> None:
         # Test that we immediately end the Session and send an error to the log if


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently there isn't a place to store manifest files for a session, so the files are being dumped in the temp directory.

### What was the solution? (How)
Create a new folder in the working directory of the session to hold the manifest files. The folder will be owned by the user creating the session directory rather than the user specified for running sub-processes. This will stop any modification of the manifest files by running jobs.

### What is the impact of this change?
A new folder will be created in the top of the session directory and cleaned up when the session is deleted.

### How was this change tested?
* unit tests all passed
* Ran a job on a CMF and confirmed the folder has the proper permissions and is cleaned up upon job completion

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*