### PR TITLE
feat!: reuse ParameterValueType from model package

### DIFF
--- a/src/openjd/sessions/__init__.py
+++ b/src/openjd/sessions/__init__.py
@@ -10,7 +10,6 @@ from ._types import (
     EnvironmentModel,
     EnvironmentScriptModel,
     Parameter,
-    ParameterType,
     StepScriptModel,
 )
 from ._version import version
@@ -23,7 +22,6 @@ __all__ = (
     "EnvironmentScriptModel",
     "LOG",
     "Parameter",
-    "ParameterType",
     "PathFormat",
     "PathMappingRule",
     "PosixSessionUser",

--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -16,7 +16,7 @@ from tempfile import gettempdir, mkstemp
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Callable, Optional, Type, Union
 
-from openjd.model import SchemaVersion, SymbolTable
+from openjd.model import ParameterValueType, SchemaVersion, SymbolTable
 from openjd.model import version as model_version
 from openjd.model.v2023_09 import (
     ValueReferenceConstants as ValueReferenceConstants_2023_09,
@@ -37,7 +37,6 @@ from ._types import (
     EnvironmentIdentifier,
     EnvironmentModel,
     Parameter,
-    ParameterType,
     StepScriptModel,
 )
 from ._version import version
@@ -726,7 +725,7 @@ class Session(object):
         """Construct a SymbolTable, with fully qualified value names, suitable for running a Script."""
 
         def processed_parameter_value(param: Parameter, value: str) -> str:
-            if param.type == ParameterType.PATH and self._path_mapping_rules is not None:
+            if param.type == ParameterValueType.PATH and self._path_mapping_rules is not None:
                 # Apply path mapping rules in the order given until one does a replacement
                 for rule in self._path_mapping_rules:
                     changed, result = rule.apply(path=value)

--- a/src/openjd/sessions/_types.py
+++ b/src/openjd/sessions/_types.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from enum import Enum
 
+from openjd.model import ParameterValueType
 from openjd.model.v2023_09 import Action as Action_2023_09
 from openjd.model.v2023_09 import EmbeddedFiles as EmbeddedFiles_2023_09
 from openjd.model.v2023_09 import EmbeddedFileText as EmbeddedFileText_2023_09
@@ -38,16 +39,9 @@ class ActionState(str, Enum):
     return code."""
 
 
-class ParameterType(str, Enum):
-    INT = "INT"
-    FLOAT = "FLOAT"
-    STRING = "STRING"
-    PATH = "PATH"
-
-
 @dataclass(frozen=True)
 class Parameter:
-    type: ParameterType
+    type: ParameterValueType
     name: str
     value: str
 

--- a/test/openjd/sessions/test_session.py
+++ b/test/openjd/sessions/test_session.py
@@ -15,8 +15,7 @@ from subprocess import DEVNULL, run
 
 import pytest
 
-from openjd.model import SymbolTable
-from openjd.model import SchemaVersion
+from openjd.model import ParameterValueType, SchemaVersion, SymbolTable
 from openjd.model.v2023_09 import Action as Action_2023_09
 from openjd.model.v2023_09 import (
     EmbeddedFileText as EmbeddedFileText_2023_09,
@@ -38,7 +37,6 @@ from openjd.sessions import (
     ActionState,
     ActionStatus,
     Parameter,
-    ParameterType,
     PathFormat,
     PathMappingRule,
     Session,
@@ -70,7 +68,7 @@ class TestSessionInitialization:
 
         # GIVEN
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "foo", "bar")]
+        job_params = [Parameter(ParameterValueType.STRING, "foo", "bar")]
 
         # WHEN
         session = Session(session_id=session_id, job_parameter_values=job_params)
@@ -125,7 +123,7 @@ class TestSessionInitialization:
 
         # GIVEN
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "foo", "bar")]
+        job_params = [Parameter(ParameterValueType.STRING, "foo", "bar")]
         session = Session(session_id=session_id, job_parameter_values=job_params)
         working_dir = session.working_directory
         filter = session._log_filter
@@ -154,7 +152,7 @@ class TestSessionInitialization:
 
         # GIVEN
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "foo", "bar")]
+        job_params = [Parameter(ParameterValueType.STRING, "foo", "bar")]
         session = Session(
             session_id=session_id, job_parameter_values=job_params, user=posix_target_user
         )
@@ -306,7 +304,7 @@ class TestSessionInitialization:
         # Test the context manager interface of the Session
 
         # GIVEN
-        job_params = [Parameter(ParameterType.STRING, "foo", "bar")]
+        job_params = [Parameter(ParameterValueType.STRING, "foo", "bar")]
 
         # WHEN
         with Session(session_id=session_id, job_parameter_values=job_params) as session:
@@ -326,7 +324,7 @@ class TestSessionInitialization:
             # GIVEN
             method_mock.side_effect = RuntimeError("Permission denied")
             session_id = uuid.uuid4().hex
-            job_params = [Parameter(ParameterType.STRING, "foo", "bar")]
+            job_params = [Parameter(ParameterValueType.STRING, "foo", "bar")]
             expected_error = "ERROR creating Session Working Directory: Permission denied"
 
             # WHEN
@@ -356,7 +354,7 @@ class TestSessionInitialization:
 
                     os_stat_mock.return_value = StatReturn()
                     session_id = uuid.uuid4().hex
-                    job_params = [Parameter(ParameterType.STRING, "foo", "bar")]
+                    job_params = [Parameter(ParameterValueType.STRING, "foo", "bar")]
                     expected_err_prefix = "Sticky bit is not set"
 
                     # WHEN
@@ -385,7 +383,7 @@ class TestSessionInitialization:
 
                     os_stat_mock.return_value = StatReturn()
                     session_id = uuid.uuid4().hex
-                    job_params = [Parameter(ParameterType.STRING, "foo", "bar")]
+                    job_params = [Parameter(ParameterValueType.STRING, "foo", "bar")]
                     expected_err_prefix = "WARNING: Sticky bit is not set"
 
                     # WHEN
@@ -560,8 +558,8 @@ class TestSessionRunTask_2023_09:  # noqa: N801
         # Crafting a StepScript that ensures that references both Job & Task parameters.
         # This ensures that we are correctly constructing the symbol table for the run.
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
-        task_params = [Parameter(ParameterType.STRING, "P", "Pvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
+        task_params = [Parameter(ParameterValueType.STRING, "P", "Pvalue")]
         with Session(session_id=session_id, job_parameter_values=job_params) as session:
             # WHEN
             session.run_task(step_script=fix_basic_task_script, task_parameter_values=task_params)
@@ -653,7 +651,7 @@ class TestSessionRunTask_2023_09:  # noqa: N801
 
         # GIVEN
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
         task_params = list[Parameter]()
         step_script = StepScript_2023_09(
             actions=StepActions_2023_09(
@@ -714,7 +712,7 @@ class TestSessionRunTask_2023_09:  # noqa: N801
 
         # GIVEN
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
         task_params = list[Parameter]()
         with Session(session_id=session_id, job_parameter_values=job_params) as session:
             # WHEN
@@ -733,8 +731,8 @@ class TestSessionRunTask_2023_09:  # noqa: N801
     ) -> None:
         # GIVEN
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
-        task_params = [Parameter(ParameterType.STRING, "P", "Pvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
+        task_params = [Parameter(ParameterValueType.STRING, "P", "Pvalue")]
         with Session(session_id=session_id, job_parameter_values=job_params) as session:
             # WHEN
             session.enter_environment(environment=fix_foo_baz_environment)
@@ -911,7 +909,7 @@ class TestSessionEnterEnvironment_2023_09:  # noqa: N801
             )
         )
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
         with Session(session_id=session_id, job_parameter_values=job_params) as session:
             # WHEN
             identifier = session.enter_environment(environment=environment)
@@ -1081,7 +1079,7 @@ class TestSessionEnterEnvironment_2023_09:  # noqa: N801
             )
         )
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
         with Session(session_id=session_id, job_parameter_values=job_params) as session:
             # WHEN
             session.enter_environment(environment=environment)
@@ -1149,7 +1147,7 @@ class TestSessionEnterEnvironment_2023_09:  # noqa: N801
     def test_enter_environment_with_variables(self) -> None:
         # GIVEN
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
         variables = {
             "FOO": "bar",
         }
@@ -1171,7 +1169,7 @@ class TestSessionEnterEnvironment_2023_09:  # noqa: N801
     ) -> None:
         # GIVEN
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
         variables = {
             "FOO": "{{Param.J}}",
         }
@@ -1204,7 +1202,7 @@ class TestSessionEnterEnvironment_2023_09:  # noqa: N801
     def test_enter_two_environments_with_variables(self) -> None:
         # GIVEN
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
         variables1 = {
             "FOO": "bar",
         }
@@ -1250,7 +1248,7 @@ class TestSessionExitEnvironment_2023_09:  # noqa: N801
             )
         )
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
         with Session(session_id=session_id, job_parameter_values=job_params) as session:
             identifier = session.enter_environment(environment=environment)
 
@@ -1388,7 +1386,7 @@ class TestSessionExitEnvironment_2023_09:  # noqa: N801
             )
         )
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
         with Session(session_id=session_id, job_parameter_values=job_params) as session:
             identifier = session.enter_environment(environment=environment)
 
@@ -1465,7 +1463,7 @@ class TestSessionExitEnvironment_2023_09:  # noqa: N801
     def test_exit_environment_with_variables(self) -> None:
         # GIVEN
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
         variables = {
             "FOO": "bar",
         }
@@ -1488,7 +1486,7 @@ class TestSessionExitEnvironment_2023_09:  # noqa: N801
     def test_exit_two_environments_with_variables(self) -> None:
         # GIVEN
         session_id = uuid.uuid4().hex
-        job_params = [Parameter(ParameterType.STRING, "J", "Jvalue")]
+        job_params = [Parameter(ParameterValueType.STRING, "J", "Jvalue")]
         variables1 = {
             "FOO": "bar",
         }
@@ -1893,8 +1891,8 @@ class TestPathMapping_v2023_09:  # noqa: N801
 
         # GIVEN
         params: list[Parameter] = [
-            Parameter(type=ParameterType.PATH, name="Path", value=given),
-            Parameter(type=ParameterType.STRING, name="String", value=given),
+            Parameter(type=ParameterValueType.PATH, name="Path", value=given),
+            Parameter(type=ParameterValueType.STRING, name="String", value=given),
         ]
         with Session(
             session_id="test", job_parameter_values=params, path_mapping_rules=rules


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

This Sessions package defines its own 'ParameterType' for the type of Job & Task Parameters. The 'openjd-model' package also defines a ParameterValueType that is identical. It's awkward to have to translate enums between the two libraries; they should just be using the same one.

### What was the solution? (How)

This deletes ParameterType from this package in favour of using ParameterValueType from 'openjd.model'.

### What is the impact of this change?

Writing something that needs to translate a parameter type from openjd.model to openjd.session no longer requires translating an enum type.

### How was this change tested?

I updated the unit tests.

### Was this change documented?

N/A

### Is this a breaking change?

Yes! Absolutely. The commit has been marked as breaking.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*