### PR TITLE
chore(deps)!: update to 0.2.0 of openjd-model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 requires-python = ">=3.9"
 
 dependencies = [
-  "openjd-model == 0.1.*",
+  "openjd-model == 0.2.*",
   "pywin32 == 306; platform_system == 'Windows'",
   "psutil == 5.9.*; platform_system == 'Windows'",
 ]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

0.2.0 of the openjd-model package was released, and downstream deps (openjd-cli) of this package need to use it but this package is version locked to 0.1.x.

### What was the solution? (How)

Update the dependency to 0.2.0

### What is the impact of this change?

Downstream consumers can update.

### How was this change tested?

Just by running the unit tests.

### Was this change documented?

No

### Is this a breaking change?

Technically, yes. Consumers that once explicitly depended on this and openjd-model 0.1.x would be unable to resolve the new requirement.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*