### PR TITLE
feat: Grant .\Administrators Tempdir access in Windows

### DIFF
--- a/src/openjd/sessions/_tempdir.py
+++ b/src/openjd/sessions/_tempdir.py
@@ -90,17 +90,30 @@ class TempDir:
                     else:
                         principal_to_permit = user.user
 
-                    principal_sid, _, _ = win32security.LookupAccountName(None, principal_to_permit)
+                    user_or_group_sid, _, _ = win32security.LookupAccountName(
+                        None, principal_to_permit
+                    )
+                    administrators_sid, _, _ = win32security.LookupAccountName(
+                        None, "Administrators"
+                    )
 
                     # We don't want to propagate existing permissions, so create a new DACL
                     dacl = win32security.ACL()
 
-                    # Add an ACE to the DACL giving the principal full control and enabling inheritance of the ACE
+                    # Add an ACE to the DACL giving the user or group full control and enabling inheritance of the ACE
                     dacl.AddAccessAllowedAceEx(
                         win32security.ACL_REVISION,
                         ntsecuritycon.OBJECT_INHERIT_ACE | ntsecuritycon.CONTAINER_INHERIT_ACE,
                         ntsecuritycon.FILE_ALL_ACCESS,
-                        principal_sid,
+                        user_or_group_sid,
+                    )
+
+                    # Add an ACE to the DACL giving the Administrators group full control and enabling inheritance of the ACE
+                    dacl.AddAccessAllowedAceEx(
+                        win32security.ACL_REVISION,
+                        ntsecuritycon.OBJECT_INHERIT_ACE | ntsecuritycon.CONTAINER_INHERIT_ACE,
+                        ntsecuritycon.FILE_ALL_ACCESS,
+                        administrators_sid,
                     )
 
                     # Get the security descriptor of the tempdir

--- a/test/openjd/sessions/test_tempdir.py
+++ b/test/openjd/sessions/test_tempdir.py
@@ -97,6 +97,19 @@ class TestTempDirWindowsUser:
     FULL_CONTROL_MASK = 2032127
 
     @patch("openjd.sessions.WindowsSessionUser.is_process_user", return_value=True)
+    def test_windows_user_permits_admins_group(self, mock_user_match):
+        # GIVEN
+        # Use a builtin group, so we can expect it to exist on any Windows machine
+        # The mocked `is_process_user` is only used in WindowsSessionUser for parameter validation
+        windows_user = WindowsSessionUser("arbitrary_user", group="Users")
+
+        # WHEN
+        tempdir = TempDir(user=windows_user)
+
+        # THEN
+        assert self.principal_has_full_control_of_object(str(tempdir.path), "Administrators")
+
+    @patch("openjd.sessions.WindowsSessionUser.is_process_user", return_value=True)
     def test_windows_user_with_group_permits_group(self, mock_user_match):
         # GIVEN
         # Use a builtin group, so we can expect it to exist on any Windows machine


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When creating a `Tempdir` on Windows with a `WindowsSessionUser` (indicating impersonation), `Tempdir` creates a new DACL in place of the inherited DACL containing a single ACE which grants access to the user specified by `WindowsSessionUser`.

A member of the `Administrators` group should have permissions for the `Tempdir` directory as well. 

### What was the solution? (How)
Add a new ACE to the DACL for the `Administrators` group.

### What is the impact of this change?
`Administrators` can access the `Tempdir` and the files/directories it contains.

### How was this change tested?
Unit test added

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*