### PR TITLE
feat!: differentiate canceled/timed-out actions

### DIFF
--- a/src/openjd/sessions/_types.py
+++ b/src/openjd/sessions/_types.py
@@ -30,6 +30,9 @@ class ActionState(str, Enum):
     CANCELED = "canceled"
     """The action has been canceled and is no longer running."""
 
+    TIMEOUT = "timeout"
+    """The action has been canceled due to reaching its runtime limit."""
+
     FAILED = "failed"
     """The action is no longer running, and exited with a non-zero
     return code."""

--- a/test/openjd/sessions/test_runner_base.py
+++ b/test/openjd/sessions/test_runner_base.py
@@ -398,7 +398,7 @@ class TestScriptRunnerBase:
                 time.sleep(0.2)
 
         # THEN
-        assert runner.state == ScriptRunnerState.CANCELED
+        assert runner.state == ScriptRunnerState.TIMEOUT
         messages = collect_queue_messages(message_queue)
         # The application prints out 0, ..., 9 once a second for 10s.
         # If it ended early, then we printed the first but not the last.
@@ -489,7 +489,7 @@ class TestScriptRunnerBase:
             # Wait until the process exits.
             while runner.exit_code is None:
                 time.sleep(0.2)
-            assert runner.state == ScriptRunnerState.CANCELED
+            assert runner.state == ScriptRunnerState.TIMEOUT
             assert runner.exit_code != 0
             assert cast(TerminatingRunner, runner)._cancel_called
         messages = collect_queue_messages(message_queue)
@@ -524,6 +524,8 @@ class TestScriptRunnerBase:
             # Wait until the process exits.
             while runner.exit_code is None:
                 time.sleep(0.2)
+            # This should be CANCELED rather than TIMEOUT because this test is manually calling
+            # the cancel() method rather than letting the action reach its runtime limit.
             assert runner.state == ScriptRunnerState.CANCELED
             assert runner.exit_code != 0
         messages = collect_queue_messages(message_queue)
@@ -577,6 +579,8 @@ class TestScriptRunnerBase:
             # Wait until the process exits.
             while runner.exit_code is None:
                 time.sleep(0.2)
+        # This should be CANCELED rather than TIMEOUT because this test is manually calling
+        # the cancel() method rather than letting the action reach its runtime limit.
         assert runner.state == ScriptRunnerState.CANCELED
         assert runner.exit_code != 0
         messages = collect_queue_messages(message_queue)


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

There is currently no way to know from an action's state whether a canceled action was canceled because a cancelation  as manually requested, or because that action's runtime limit was reached.

### What was the solution? (How)

Add a TIMEOUT state to ActionState. Actions that were canceled due to reaching their runtime limit will have this state rather than CANCELED.

### What is the impact of this change?

Consumers of the library will be able to differentiate an action-cancel from an action-timeout just by looking at the final state of an action, rather than having to keep track of whether they explicitly canceled the action or not.

### How was this change tested?

I updated the unit tests, and also ran the sudo-test container just for good measure.

### Was this change documented?

Yes, the new state has a docstring.

### Is this a breaking change?

**BREAKING CHANGE** - Callers will now need to check for the TIMEOUT ActionState as the completion state for actions.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*