### PR TITLE
fix: add logging for setting environment variables

### DIFF
--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -535,6 +535,8 @@ class Session(object):
             resolved_variables = self._resolve_env_variable_format_strings(
                 symtab, environment.variables
             )
+            for name, value in resolved_variables.items():
+                self._logger.info("Setting: %s=%s", name, value)
             env_var_changes = SimplifiedEnvironmentVariableChanges(resolved_variables)
             self._created_env_vars[identifier] = env_var_changes
         else:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

 There's currently no way to know if you enter an environment that defines environment variables; the logs don't show anything. This is particularly egregious if the Environment *only* defines environment variables -- it'll look like it's doing nothing.

### What was the solution? (How)

 Add a bit of logging to print out variable definitions.

### What is the impact of this change?
 
 Logs that are easier to grok.

### How was this change tested?

Just ran the unit tests. We have some that are testing environments that define variables this way; they'd have blown up if the new code had issues.

### Was this change documented?

Naw, not necessary.

### Is this a breaking change?

Nope.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*