### PR TITLE
chore: enable macOS in CI

### DIFF
--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     env:
       PYTHON: ${{ matrix.python-version }}
       CODEARTIFACT_REGION: "us-west-2"
@@ -48,8 +48,8 @@ jobs:
         aws-region: us-west-2
         mask-aws-account-id: true
 
-    - name: CodeArtifact Setup Linux
-      if: ${{ matrix.os == 'ubuntu-latest'}}
+    - name: CodeArtifact Setup Unix
+      if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
       run: |
         CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
         echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"

--- a/test/openjd/sessions/test_tempdir.py
+++ b/test/openjd/sessions/test_tempdir.py
@@ -28,7 +28,7 @@ from .conftest import has_posix_disjoint_user, has_posix_target_user
 class TestTempDirPosix:
     def test_defaults(self) -> None:
         # GIVEN
-        tmpdir = Path(tempfile.gettempdir())
+        tmpdir = Path(tempfile.gettempdir()).resolve()
 
         # WHEN
         result = TempDir()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to run our tests on macOS.

### What was the solution? (How)
This PR adds macos-latest to our CI runners and adjusts a test to work on macOS.

### What is the impact of this change?
We have macOS CIs

### How was this change tested?
Ran the unit tests on macOS and Linux

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*