### PR TITLE
test: Add test user in Windows github actions

### DIFF
--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -35,6 +35,17 @@ jobs:
       with:
         ref: ${{ inputs.branch }}
         fetch-depth: 0
+    
+    - name: Create Windows Test User
+      if: ${{ matrix.os == 'windows-latest'}}
+      run: |
+        $username = 'openjdtester'
+        $plaintext_password = -join([char[]](48..122) | Get-Random -Count 16)
+        $password = ConvertTo-SecureString $plaintext_password -AsPlainText -Force
+        New-LocalUser -Name $username -Password $password
+        echo OJD_SESSIONS_USER_NAME=$username >> $env:GITHUB_ENV
+        echo "::add-mask::$plaintext_password"
+        echo OJD_SESSIONS_USER_PASSWORD=$plaintext_password >> $env:GITHUB_ENV
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
To support cross-account testing on Windows locally and in Github Actions, we need a mechanism to pass a valid username and password to the test code. Locally, it will be the responsibility of the developer to create the user and export the corresponding username and password as environment variables. Github Actions will automatically create the user and export the environment variables.

### What was the solution? (How)
- Create test fixture to create `WindowsSessionUser` from environment variables
- Create method to check for presence of environment variables and validate credentials. This will be used to skip cross-user tests locally when the variables are not set
- Add step to code quality job. This job creates a new user and exports the username and plaintext password as environment variables.

### What is the impact of this change?
Future cross-account tests can use an existing local user.

### How was this change tested?
N/A

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*