### PR TITLE
chore: Change default windows working directory to the "C:\ProgramData\Amazon"

### DIFF
--- a/test/openjd/sessions/test_session.py
+++ b/test/openjd/sessions/test_session.py
@@ -379,7 +379,7 @@ class TestSessionInitialization:
     @pytest.mark.usefixtures("caplog")  # built-in fixture
     def test_posix_permissions_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         # On POSIX systems, we check the sticky bit of the system /tmp dir
-        # If its not set, then we emit a security warning into the logs.
+        # If it is not set, then we emit a security warning into the logs.
         # This tests that we do in fact emit that message when the sticky bit isn't set.
         with patch("openjd.sessions._session.TempDir", MagicMock()):
             with patch("openjd.sessions._session.os_name", "posix"):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Before this change, the default path is generated by gettempdir(), which is returning a temporary directory within the current user's profile. For example, `C:\Users\UserA\AppData\Local\Temp\`
That's undesirable because that means that in the cross-user case we're giving a 2nd user access to a directory within the 1st user's profile.

### What was the solution? (How)
Change the default tmp dir to the `C:\ProgramData\Amazon`

### What is the impact of this change?
Default tmp dir will be changed to the `C:\ProgramData\Amazon`

### How was this change tested?
A new integration test is added.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*