### PR TITLE
test: Add test_runner_base windows impersonation tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,4 +151,4 @@ source = [
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 83
+fail_under = 82

--- a/src/openjd/sessions/_windows_permission_helper.py
+++ b/src/openjd/sessions/_windows_permission_helper.py
@@ -1,0 +1,63 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from ._os_checker import is_windows
+
+if is_windows():
+    import win32security
+    import ntsecuritycon
+
+
+class WindowsPermissionHelper:
+    """
+    This class contains helper methods to set permissions for files and directories on Windows.
+    """
+
+    @staticmethod
+    def set_permissions_full_control(file_path, principals_to_permit):
+        """
+        Grants full control over the object at file_path to all principals in principals_to_permit.
+        Sets flags so both child files and directories inherit these permissions.
+
+        Arguments:
+            file_path (str): The path to the file or directory.
+            principals_to_permit (List[str]): The names of the principals to permit.
+
+        Raises:
+            RuntimeError if there is a problem modifying the security attributes.
+        """
+        try:
+            # We don't want to propagate existing permissions, so create a new DACL
+            dacl = win32security.ACL()
+            for principal in principals_to_permit:
+                user_or_group_sid, _, _ = win32security.LookupAccountName(None, principal)
+
+                # Add an ACE to the DACL giving the principal full control and enabling inheritance of the ACE
+                dacl.AddAccessAllowedAceEx(
+                    win32security.ACL_REVISION,
+                    ntsecuritycon.OBJECT_INHERIT_ACE | ntsecuritycon.CONTAINER_INHERIT_ACE,
+                    ntsecuritycon.FILE_ALL_ACCESS,
+                    user_or_group_sid,
+                )
+
+            # Get the security descriptor of the tempdir
+            sd = win32security.GetFileSecurity(
+                str(file_path), win32security.DACL_SECURITY_INFORMATION
+            )
+
+            # Set the security descriptor's DACL to the newly-created DACL
+            # Arguments:
+            # 1. bDaclPresent = 1: Indicates that the DACL is present in the security descriptor.
+            #    If set to 0, this method ignores the provided DACL and allows access to all principals.
+            # 2. dacl: The discretionary access control list (DACL) to be set in the security descriptor.
+            # 3. bDaclDefaulted = 0: Indicates the DACL was provided and not defaulted.
+            #    If set to 1, indicates the DACL was defaulted, as in the case of permissions inherited from a parent directory.
+            sd.SetSecurityDescriptorDacl(1, dacl, 0)
+
+            # Set the security descriptor to the tempdir
+            win32security.SetFileSecurity(
+                str(file_path), win32security.DACL_SECURITY_INFORMATION, sd
+            )
+        except Exception as err:
+            raise RuntimeError(
+                f"Could not change permissions of directory '{str(dir)}' (error: {str(err)})"
+            )

--- a/test/openjd/sessions/conftest.py
+++ b/test/openjd/sessions/conftest.py
@@ -14,6 +14,7 @@ from openjd.sessions._os_checker import is_posix, is_windows
 
 WIN_USERNAME_ENV_VAR = "OJD_SESSIONS_USER_NAME"
 WIN_PASS_ENV_VAR = "OJD_SESSIONS_USER_PASSWORD"
+SET_ENV_VARS_MESSAGE = f"To run impersonation test, environment vars {WIN_USERNAME_ENV_VAR} and {WIN_PASS_ENV_VAR} must be set."
 
 
 def build_logger(handler: QueueHandler) -> LoggerAdapter:

--- a/test/openjd/sessions/test_session.py
+++ b/test/openjd/sessions/test_session.py
@@ -836,15 +836,17 @@ class TestSessionCancel:
     @pytest.mark.parametrize(
         argnames="time_limit",
         argvalues=(
-            None,
-            timedelta(seconds=1),
-            timedelta(seconds=2),
-        )
-        if is_posix()
-        else (
-            None,
-            timedelta(seconds=2),
-            timedelta(seconds=3),
+            (
+                None,
+                timedelta(seconds=1),
+                timedelta(seconds=2),
+            )
+            if is_posix()
+            else (
+                None,
+                timedelta(seconds=2),
+                timedelta(seconds=3),
+            )
         ),
     )
     def test_cancel_time_limit(self, time_limit: Optional[timedelta]) -> None:
@@ -903,12 +905,16 @@ def _make_environment(
     script = (
         EnvironmentScript_2023_09(
             actions=EnvironmentActions_2023_09(
-                onEnter=Action_2023_09(command=sys.executable, args=["{{ Env.File.Foo }}"])
-                if enter_script
-                else None,
-                onExit=Action_2023_09(command=sys.executable, args=["{{ Env.File.Foo }}"])
-                if exit_script
-                else None,
+                onEnter=(
+                    Action_2023_09(command=sys.executable, args=["{{ Env.File.Foo }}"])
+                    if enter_script
+                    else None
+                ),
+                onExit=(
+                    Action_2023_09(command=sys.executable, args=["{{ Env.File.Foo }}"])
+                    if exit_script
+                    else None
+                ),
             ),
             embeddedFiles=[
                 EmbeddedFileText_2023_09(

--- a/test/openjd/sessions/test_subprocess.py
+++ b/test/openjd/sessions/test_subprocess.py
@@ -14,11 +14,6 @@ from queue import SimpleQueue
 from typing import Union
 from unittest.mock import MagicMock
 
-from openjd.sessions._os_checker import is_windows
-
-if is_windows():
-    import win32api
-
 import pytest
 
 from openjd.sessions._os_checker import is_posix, is_windows
@@ -93,7 +88,7 @@ class TestLoggingSubprocessSameUser:
             current_user = getpass.getuser()
             user = PosixSessionUser(user=current_user)
         else:
-            current_user = win32api.GetUserNameEx(win32api.NameSamCompatible)
+            current_user = WindowsSessionUser.get_process_user()
             user = WindowsSessionUser(user=current_user)
 
         logger = build_logger(queue_handler)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want cross-user tests for the `runner_base` module on Windows.

### What was the solution? (How)
Add tests to verify run-as works and environment variables are not inherited.

### What is the impact of this change?
Cross-user `runner_base` functionality is tested.

### How was this change tested?
Tests pass.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*