### PR TITLE
feat!: update to openjd-model 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [
-  "openjd-model == 0.2.*",
+  "openjd-model == 0.3.*",
   "pywin32 == 306; platform_system == 'Windows'",
   "psutil == 5.9.*; platform_system == 'Windows'",
 ]

--- a/test/openjd/sessions/test_session.py
+++ b/test/openjd/sessions/test_session.py
@@ -15,7 +15,7 @@ from subprocess import DEVNULL, run
 
 import pytest
 
-from openjd.model import ParameterValue, ParameterValueType, SchemaVersion, SymbolTable
+from openjd.model import ParameterValue, ParameterValueType, SpecificationRevision, SymbolTable
 from openjd.model.v2023_09 import Action as Action_2023_09
 from openjd.model.v2023_09 import (
     EmbeddedFileText as EmbeddedFileText_2023_09,
@@ -1743,7 +1743,7 @@ class TestPathMapping_v2023_09:  # noqa: N801
             session_id=session_id, job_parameter_values=job_params, path_mapping_rules=rules
         ) as session:
             # WHEN
-            session._materialize_path_mapping(SchemaVersion.v2023_09, env_vars, symtab)
+            session._materialize_path_mapping(SpecificationRevision.v2023_09, env_vars, symtab)
 
             # THEN
             assert symtab["Session.HasPathMappingRules"] == ("true" if rules else "false")
@@ -1985,7 +1985,7 @@ class TestPathMapping_v2023_09:  # noqa: N801
         ) as session:
             # WHEN
             with patch(f"{path_mapping_impl_mod.__name__}.os_name", "posix"):
-                symtab = session._symbol_table(SchemaVersion.v2023_09, params)
+                symtab = session._symbol_table(SpecificationRevision.v2023_09, params)
 
         # THEN
         assert symtab["RawParam.Path"] == given


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

 openjd-model 0.3.0 has been released and is a breaking change. Notably, the change is breaking in that the 'SchemaVersion' enum is removed and replaced with SpecificationRevision and TemplateSpecificationVersion. 

### What was the solution? (How)

Replace uses of `SchemaVersion` with `SpecificationRevision`, and bump the required version of openjd-model

### What is the impact of this change?

This allows downstream consumers of this library (e.g. the openjd-cli) to benefit from recent improvements made to the model validation logic and messaging in the openjd-model library.

### How was this change tested?

The impacted code is covered by unit tests.

### Was this change documented?

N/A

### Is this a breaking change?

Yes.  This is marked as a breaking change since downstream consumers of this library would break if they took on this change without updating their code to apply the openjd-model changes.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*