### PR TITLE
fix: Allow openjd_env to set vars to empty

### DIFF
--- a/src/openjd/sessions/_action_filter.py
+++ b/src/openjd/sessions/_action_filter.py
@@ -33,7 +33,7 @@ filter_regex = (
 filter_matcher = re.compile(filter_regex)
 
 # A regex for matching the assignment of a value to an environment variable
-envvar_set_regex = "^[A-Za-z_][A-Za-z0-9_]*" "=" ".+$"  # Variable name
+envvar_set_regex = "^[A-Za-z_][A-Za-z0-9_]*" "=" ".*$"  # Variable name
 envvar_set_matcher = re.compile(envvar_set_regex)
 envvar_unset_regex = "^[A-Za-z_][A-Za-z0-9_]*$"
 envvar_unset_matcher = re.compile(envvar_unset_regex)
@@ -214,7 +214,7 @@ class ActionMonitoringFilter(logging.Filter):
         # where:
         #   <varname> consists of latin alphanumeric characters and the underscore,
         #             and starts with a non-digit
-        #   <value> can be any characters.
+        #   <value> can be any characters including empty.
         if not envvar_set_matcher.match(message):
             raise ValueError("Failed to parse environment variable assignment.")
         name, _, value = message.partition("=")

--- a/test/openjd/sessions/test_action_filter.py
+++ b/test/openjd/sessions/test_action_filter.py
@@ -72,6 +72,12 @@ class TestActionMonitoringFilter:
                 id="env, allowable characters",
             ),
             pytest.param(
+                "openjd_env: foo=",
+                ActionMessageKind.ENV,
+                {"name": "foo", "value": ""},
+                id="env, assign empty",
+            ),
+            pytest.param(
                 "openjd_env: foo= ",
                 ActionMessageKind.ENV,
                 {"name": "foo", "value": " "},
@@ -281,10 +287,6 @@ class TestActionMonitoringFilter:
             pytest.param(
                 "openjd_env: foo",
                 id="env, missing assignment",
-            ),
-            pytest.param(
-                "openjd_env: foo=",
-                id="env, missing value",
             ),
             pytest.param(
                 "openjd_env: foo =value",


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The `openjd_env` stdout handler provides a means by which an environment enter action in a Session can export OS environment variables to subsequent actions in the same session. The implementation of this does not currently allow setting empty environment variables as in:
```
openjd_env: REZ_PLATFORM_PATCH_VERSION=
```

### What was the solution? (How)

Adjust the regex to allow empty environment variable values.

### What is the impact of this change?

Users that are manifesting a, say, a Rez environment during an Environment enter should be able to do so now without errors.

### How was this change tested?

This is unit tested.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*