### PR TITLE
test: Add windows embedded_files impersonation tests

### DIFF
--- a/src/openjd/sessions/_embedded_files.py
+++ b/src/openjd/sessions/_embedded_files.py
@@ -16,8 +16,10 @@ from openjd.model.v2023_09 import EmbeddedFileText as EmbeddedFileText_2023_09
 from openjd.model.v2023_09 import (
     ValueReferenceConstants as ValueReferenceConstants_2023_09,
 )
-from ._session_user import PosixSessionUser, SessionUser
+from ._session_user import PosixSessionUser, SessionUser, WindowsSessionUser
 from ._types import EmbeddedFilesListType, EmbeddedFileType
+
+from openjd.sessions._windows_permission_helper import WindowsPermissionHelper
 
 __all__ = ("EmbeddedFilesScope", "EmbeddedFiles")
 
@@ -66,6 +68,14 @@ def write_file_for_user(
         # The file may have already existed before calling this function (e.g. created by mkstemp)
         # so unconditionally set the file permissions to ensure that additional_permissions are set.
         os.chmod(filename, mode=mode)
+
+    elif os.name == "nt":
+        if user is not None:
+            user = cast(WindowsSessionUser, user)
+            process_user = WindowsSessionUser.get_process_user()
+            WindowsPermissionHelper.set_permissions_full_control(
+                str(filename), [process_user, user.user]
+            )
 
 
 class EmbeddedFilesScope(Enum):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The EmbeddedFiles module should have unit tests for Windows user impersonation.

### What was the solution? (How)
- Add tests
- Add logic to set permissions on embedded files. The EmbeddedFiles module already works in the context of the Session because the Session's tempdir contains the embedded files directory and permissions are inherited. This change makes the EmbeddedFiles functionality on Windows closer to what's on Posix by enabling the module to also function outside of a tempdir with permission inheritance of ACLs permitting the process user and impersonated user.

### What is the impact of this change?
Windows impersonation functionality of EmbeddedFiles module is tested.

### How was this change tested?
Tests pass

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*