### PR TITLE
feat!: public release

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -41,11 +41,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    env:
-      CODEARTIFACT_REGION: "us-west-2"
-      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,17 +85,9 @@ jobs:
             echo EOF
           } >> $GITHUB_ENV
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-          aws-region: us-west-2
-          mask-aws-account-id: true
-
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
-          export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
           pip install --upgrade hatch
           hatch build
 
@@ -174,13 +161,6 @@ jobs:
           ref: release
           fetch-depth: 0
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-          aws-region: us-west-2
-          mask-aws-account-id: true
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -188,14 +168,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
           pip install --upgrade hatch
           pip install --upgrade twine
 
       - name: Build
         run: hatch build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
 
       - name: Publish to Repository
         run: |

--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -22,10 +22,6 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     env:
       PYTHON: ${{ matrix.python-version }}
-      CODEARTIFACT_REGION: "us-west-2"
-      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
     - uses: actions/checkout@v4
       if: ${{ !inputs.branch }}
@@ -52,27 +48,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-        aws-region: us-west-2
-        mask-aws-account-id: true
-
-    - name: CodeArtifact Setup Unix
-      if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
-      run: |
-        CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
-
-    - name: CodeArtifact Setup Windows
-      if: ${{ matrix.os == 'windows-latest'}}
-      run: |
-        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
-
     - name: Install Dependencies
       run: pip install --upgrade -r requirements-development.txt
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Open Job Description - Sessions for Python
 
+[![pypi](https://img.shields.io/pypi/v/openjd-sessions.svg)](https://pypi.python.org/pypi/openjd-sessions)
+
 Open Job Description is a flexible open specification for defining render jobs which are portable
 between studios and render solutions. This package provides a library that can be used to build
 a runtime that is able to run Jobs in a
@@ -20,6 +22,11 @@ This library requires:
 4. On Windows:
     * PowerShell 5.x
 
+**EXPERIMENTAL** Note that compatibility with the Windows operating system is currently in active development
+and should be considered to be experimental. We recommend that this library not be used in Windows-based
+production environments at this time. We will remove this notice when Windows compatibility is considered
+sufficiently stable and secure for use in Windows-based production environments.
+
 ## Versioning
 
 This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its 
@@ -29,6 +36,13 @@ versions will increment during this initial development stage, they are describe
 1. The MAJOR version is currently 0, indicating initial development. 
 2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
 3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API.
+
+## Contributing
+
+We encourage all contributions to this package.  Whether it's a bug report, new feature, correction, or additional
+documentation, we greatly value feedback and contributions from our community.
+
+Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for our contributing guidelines.
 
 ## Example Usage
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -23,14 +23,8 @@ lint = [
 [[envs.all.matrix]]
 python = ["3.9", "3.10", "3.11"]
 
-[envs.default.env-vars]
-PIP_INDEX_URL="https://aws:{env:CODEARTIFACT_AUTH_TOKEN}@{env:CODEARTIFACT_DOMAIN}-{env:CODEARTIFACT_ACCOUNT_ID}.d.codeartifact.{env:CODEARTIFACT_REGION}.amazonaws.com/pypi/{env:CODEARTIFACT_REPOSITORY}/simple/"
-
 [envs.codebuild.scripts]
 build = "hatch build"
-
-[envs.codebuild.env-vars]
-PIP_INDEX_URL=""
 
 [envs.container.env-vars]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,13 @@ classifiers = [
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [
-  "openjd-model == 0.3.*",
+  "openjd-model == 0.4.*",
   "pywin32 == 306; platform_system == 'Windows'",
   "psutil == 5.9.*; platform_system == 'Windows'",
 ]
 
 [project.urls]
-Homepage = "https://github.com/OpenJobDescription/openjd-specifications/wiki"
+Homepage = "https://github.com/OpenJobDescription/openjd-sessions-for-python"
 Source = "https://github.com/OpenJobDescription/openjd-sessions-for-python"
 
 [tool.hatch.build]
@@ -99,15 +99,16 @@ mypy_path = "src"
 plugins = "pydantic.mypy"
 
 [tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
 ignore = [
   "E501",
   # Double Check if this should be fixed
   "E731",
 ]
-line-length = 100
 
-
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 classmethod-decorators = [
   "classmethod",
   # pydantic decorators are classmethod decorators
@@ -116,7 +117,7 @@ classmethod-decorators = [
   "pydantic.root_validator",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = [
   "openjd",
 ]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We're about to publicly release this library. We need to prep the build process for that.

### What was the solution? (How)

- Update the build script to no longer define a PIP_INDEX_URL -- the environment variable
  that we used to interface with our internal repository during private development.
- Update the code quality check to pull deps from the public PyPI, so
  that we're testing as customers would use it.
- Use the public PyPI in the release flows since all deps are now
  available publicly. This ensures that the artifact we release can be
  built & used by anyone using PyPI.
- Increment the openjd-model dependency to the first publicly available
  version.
- Small additions to the README.

### What is the impact of this change?

Release readiness

### How was this change tested?

Just building the hatch environment.

### Was this change documented?

Yes, it is documentation as well.

### Is this a breaking change?

Yes, the bump in dependency on the openjd-model package is a breaking change in that consumers of this library will also need to take on that update.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*