### PR TITLE
fix: Make tempdir create parent dir if nonexistent

### DIFF
--- a/src/openjd/sessions/_tempdir.py
+++ b/src/openjd/sessions/_tempdir.py
@@ -37,11 +37,13 @@ def custom_gettempdir(logger: Optional[LoggerAdapter] = None) -> str:
                     f'"PROGRAMDATA" is not set. Set the root directory to the {program_data_path}'
                 )
 
-        temp_dir = os.path.join(program_data_path, "Amazon")
-        os.makedirs(temp_dir, exist_ok=True)
+        temp_dir_parent = os.path.join(program_data_path, "Amazon")
     else:
-        temp_dir = gettempdir()
-    return os.path.join(temp_dir, "OpenJD")
+        temp_dir_parent = gettempdir()
+
+    temp_dir = os.path.join(temp_dir_parent, "OpenJD")
+    os.makedirs(temp_dir, exist_ok=True)
+    return temp_dir
 
 
 class TempDir:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The following test failures occur intermittently in the Github Actions:

```
FAILED test/openjd/sessions/test_runner_base.py::TestScriptRunnerBase::test_run_as_windows_user - RuntimeError: Could not create temp directory within C:\ProgramData\Amazon\OpenJD: [WinError 3] The system cannot find the path specified: 'C:\\ProgramData\\Amazon\\OpenJD\\tmp8ln05x6l'
FAILED test/openjd/sessions/test_runner_base.py::TestScriptRunnerBase::test_does_not_inherit_env_vars_windows - RuntimeError: Could not create temp directory within C:\ProgramData\Amazon\OpenJD: [WinError 3] The system cannot find the path specified: 'C:\\ProgramData\\Amazon\\OpenJD\\tmp4gizch4h'
```
[Example](https://github.com/OpenJobDescription/openjd-sessions-for-python/actions/runs/7888350032/job/21525665690)

The failures began after #63, which moved the temporary directory from the process user's Users directory to the user-agnostic ProgramData directory and modified the directory creation logic to create the tempdir in the `Amazon\OpenJD` directory in lieu of that returned by `tempfile.gettempdir()`. With the current implementation, if `C:\ProgramData\Amazon\` does not exist, `tempdir` will fail to create the temporary directory. The test intermittently passes in Github Actions when any test which creates a `Session` object runs before the `tempdir` or `runner_base` tests because the `Session` constructor [creates the Amazon\OpenJD directory](https://github.com/OpenJobDescription/openjd-sessions-for-python/blob/mainline/src/openjd/sessions/_session.py#L799).

### What was the solution? (How)
Make `TempDir.custom_gettempdir()` create the `Amazon\OpenJD` directory on Windows if it does not yet exist.

### What is the impact of this change?
The tempdir class is no longer dependent on a pre-existing `Amazon\OpenJD` directory. Tests pass consistently.

### How was this change tested?
- Reproduced failures locally before this change as follows:
  - Removed `Amazon\OpenJD directory`
  - Ran just the tempdir unit tests, verifying failures occurred with the same error we see in Github Actions
- Verified tempdir tests pass after this change following the above steps

### Was this change documented?
N/A

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*