### PR TITLE
chore: enable cross-user linux tests in CI

### DIFF
--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -43,6 +43,41 @@ jobs:
         echo "::add-mask::$plaintext_password"
         echo OJD_SESSIONS_USER_PASSWORD=$plaintext_password >> $env:GITHUB_ENV
 
+    - name: Create Linux Test User
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        set -eou pipefail
+
+        TARGET_USER=targetuser
+        SHARED_GROUP=sharedgroup
+        DISJOINT_USER=disjointuser
+        DISJOINT_GROUP=disjointgroup
+
+        echo HOSTUSER=$(whoami)
+
+        sudo addgroup $SHARED_GROUP
+        sudo useradd -ms /bin/bash -G $SHARED_GROUP $TARGET_USER
+        sudo usermod -a -G $SHARED_GROUP $(whoami)
+        # sudo usermod -g $SHARED_GROUP $(whoami)
+        echo "$(whoami) ALL=($TARGET_USER,$(whoami)) NOPASSWD: ALL" | sudo tee -a /etc/sudoers.d/$(whoami)
+
+        sudo addgroup $DISJOINT_GROUP
+        sudo useradd -ms /bin/bash -G $DISJOINT_GROUP $DISJOINT_USER
+
+        for user in $TARGET_USER $DISJOINT_USER $(whoami)
+        do
+          echo "$user is UID: $(id -u $user)"
+          groups $user
+        done
+
+        echo OPENJD_TEST_SUDO_TARGET_USER=$TARGET_USER >> $GITHUB_ENV
+        echo OPENJD_TEST_SUDO_SHARED_GROUP=$SHARED_GROUP >> $GITHUB_ENV
+        echo OPENJD_TEST_SUDO_DISJOINT_USER=$DISJOINT_USER >> $GITHUB_ENV
+        echo OPENJD_TEST_SUDO_DISJOINT_GROUP=$DISJOINT_GROUP >> $GITHUB_ENV
+
+        umask
+        cat /etc/group
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/src/openjd/sessions/_embedded_files.py
+++ b/src/openjd/sessions/_embedded_files.py
@@ -55,6 +55,12 @@ def write_file_for_user(
 
     if os.name == "posix":
         if user is not None:
+            # DEBUGGING - Print permissions of the whole file path
+            print("For file:", filename)
+            for i in range(1, len(filename.parts) + 1):
+                subpath = Path().joinpath(*filename.parts[0:i])
+                print(subpath, subpath.stat())
+            # END DEBUGGING
             user = cast(PosixSessionUser, user)
             # Set the group of the file
             chown(filename, group=user.group)


### PR DESCRIPTION
WIP - Trying to figure out what's different about the CI environment; I'm getting unexpected file permissions errors.

### What was the problem/requirement? (What/Why)

This library has functionality that allows it to run subprocesses as a user that is different from the current user. We have unit/integration tests that verify this functionality is working. Right now, a developer is expected to run the scripts/run_sudo_tests.sh set of tests before putting up a pull request to make sure that a change doesn't break the functionality. This isn't reliable so we should have these tests enabled in the GitHub CI; this does that.

### What was the solution? (How)

These tests are enabled by setting values for certain environment variables. The docker container setup under `testing_containers/localuser_sudo_environment/Dockerfile` shows these variables, so I just mirrored them in to the CI while also creating the requisite user & sudoers file configuration.

### What is the impact of this change?

More confidence in our CI testing.

### How was this change tested?

It is tests. Verify the CI test output for the Linux platforms. We should not see any xfail posix-specific tests if this has worked.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*