### PR TITLE
For comment: Support running in a windows service

### DIFF
--- a/src/openjd/sessions/__init__.py
+++ b/src/openjd/sessions/__init__.py
@@ -8,7 +8,6 @@ from ._session_user import (
     SessionUser,
     WindowsSessionUser,
     BadCredentialsException,
-    BadUserNameException,
 )
 from ._types import (
     ActionState,
@@ -36,6 +35,5 @@ __all__ = (
     "StepScriptModel",
     "WindowsSessionUser",
     "BadCredentialsException",
-    "BadUserNameException",
     "version",
 )

--- a/src/openjd/sessions/_embedded_files.py
+++ b/src/openjd/sessions/_embedded_files.py
@@ -19,7 +19,11 @@ from openjd.model.v2023_09 import (
 from ._session_user import PosixSessionUser, SessionUser, WindowsSessionUser
 from ._types import EmbeddedFilesListType, EmbeddedFileType
 
-from openjd.sessions._windows_permission_helper import WindowsPermissionHelper
+from ._windows_permission_helper import WindowsPermissionHelper
+from ._os_checker import is_windows
+
+if is_windows():
+    from ._win32._helpers import get_process_user
 
 __all__ = ("EmbeddedFilesScope", "EmbeddedFiles")
 
@@ -72,7 +76,7 @@ def write_file_for_user(
     elif os.name == "nt":
         if user is not None:
             user = cast(WindowsSessionUser, user)
-            process_user = WindowsSessionUser.get_process_user()
+            process_user = get_process_user()
             WindowsPermissionHelper.set_permissions_full_control(
                 str(filename), [process_user, user.user]
             )

--- a/src/openjd/sessions/_session_user.py
+++ b/src/openjd/sessions/_session_user.py
@@ -3,6 +3,7 @@
 import os
 from typing import Optional, Tuple, Union
 from abc import ABC, abstractmethod
+from ctypes.wintypes import HANDLE
 
 from ._os_checker import is_posix, is_windows
 
@@ -94,8 +95,90 @@ class PosixSessionUser(SessionUser):
 
 
 class WindowsSessionUser(SessionUser):
-    __slots__ = ("user", "group", "password")
     """Specific os-user identity to run a Session as under Windows."""
+
+    # Background to know:
+    #  - What's a "Session" in Windows?
+    #     - https://techcommunity.microsoft.com/t5/ask-the-performance-team/sessions-desktops-and-windows-stations/ba-p/372473
+    #     - tl;dr - A security environment encapsulating processes and system objects for a logon.
+    #  - Session0 in Windows is special. It's where all os services run.
+    #     - https://techcommunity.microsoft.com/t5/ask-the-performance-team/application-compatibility-session-0-isolation/ba-p/372361
+    #  - The method for creating an impersonated process seems to differ based on whether you're in session 0 or not.
+    #     - I suspect that this is a process privilege thing, but have been unable (so far) to figure out what collection of
+    #       privileges allow the Session 0 impersonation code to run successfully outside of Session 0.
+    #     - In Session != 0:
+    #        - Can use win32 API "CreateProcessWithLogon" which takes a username+password, and runs the process as that user.
+    #     - In Session = 0:
+    #        - CreateProcessWithLogon does not work; at all.
+    #        - Must use CreateProcessAsUser or CreateProcessWithToken. We got AsUser working, so we use that.
+    #        - CreateProcessAsUser/Token both require a "logon token" rather than a user+pass.
+    #          - A token is just an OS object that represents something; a logon in this case.
+    #        - Use LogonUserW (or related APIs) to create a logon token.
+    #        - We must also explicitly load the user's profile into the logon token using win32api LoadUserProfile
+    #  - A process can have only one logon token for each user; trying to create a second when you already have one you
+    #    will get a "A required privilege is not held by the client" when you try to LoadUserProfile in to that new token.
+    #     - This might be actually be an error that you cannot LoadUserProfile when a token lives that has already loaded the
+    #       profile.
+    #  - A process that creates a logon token, and loads a profile, is must both: UnloadUserProfile and Close the token.
+    # Much more nuanced detail: https://github.com/ddneilson/Win32Impersonation
+
+    # Proposed behavior:
+    #  If running in Session != 0 (i.e. interactive logon):
+    #    - Token to __init__ not permitted
+    #    - If not process user, then password required.
+    #    - If process user, then password forbidden
+    #    - In LoggingSubprocess:
+    #       - If user != process user: use CreateProcessWithLogon
+    #       - Else, use standard Popen
+    #  Else; running in Session0 (i.e. Within an OS Service)
+    #    - If not process user, then exactly one of password or token required.
+    #    - If process user, then password & token forbidden.
+    #    - If token is given, then just use it
+    #       - Assume the caller has correctly constructed it, and loaded profile.
+    #    - Else; password is given:
+    #       - We retain an internal cache mapping user -> logon token
+    #          - WeakRefValue dictionary.
+    #          - Each 'value' is an object that has a __del__ method that will unload profile & close token
+    #       - Lookup the user in the cache; 
+    #          - if exists, then embed a reference to it in this instance
+    #          - if not exists, then create a new logon w/ profile load and cache it.
+    #       - In LogggingSubprocess:
+    #          - If user has a token; then use CreateProcessAsUser to run the subprocess
+    #          - Else, use standard Popen
+    #       - Documentation to say either always use a token or never use a token; don't mix & match.
+    #       - Recommend that consumers maintain their own cache of WindowsSessionUser objects or logon tokens if they
+    #         want to avoid doing redoing logon + profile loads during the run of the program 
+    #         (e.g. roaming profiles won't initially be supported, but may be a significant load time when supported)
+    #      
+    #
+    # Alternatives:
+    #  - Which win32 APIs we use when is not up for debate; we're limited in what APIs are available when
+    #    to create processes.
+    #  - 1) Create a separate `WindowsSessionTokenUser` that takes user+group+logon_token
+    #       - This class `WindowsSessionUser` would remain unmodified by this PR
+    #       - Suboption A)
+    #          - Caller is responsible for creating the logon token, and implementing the code to create it.
+    #       - Suboption B)
+    #          - Caller is responsible for creating the logon token, but we provide logon_user/logout_user
+    #            helper functions in our public API to assist. Caller is responsible for the lifecycle of
+    #            tokens.
+    #       - Suboption C)
+    #          - Caller is responsible for creating the logon token, but we provide a logon-token cache
+    #            as described in the proposed solution.
+    #       - Suboption D)
+    #          - As (C) but the interface to the token-cache is a method on WindowsSessionUser.
+    #             - Caller creates a WindowsSessionUser with the password
+    #             - Then caller calls WindowsSessionUser.create_token_user() to get a WindowsSessionTokenUser
+    #               instance with a cached logon token.
+    #      - This alternative, and all suboptions, discarded as it forces the caller to be aware of the nuances
+    #        of impersonation in win32 API. i.e. They have to know that being in Session 0 means that the
+    #        WindowsSessionUser instance isn't usable.
+    #
+    # TBD - Errors. I don't want pywin32 exceptions or ctypes.WinError exceptions to be part of our contract;
+    #       that bleeds the abstraction around what interface we're using to run processes, and makes it a breaking
+    #       change to change an internal implementation detail if we did surface those exceptions.
+
+    __slots__ = ("user", "group", "password")
 
     user: str
     """
@@ -117,19 +200,34 @@ class WindowsSessionUser(SessionUser):
     """
 
     def __init__(
-        self, user: str, *, password: Optional[str] = None, group: Optional[str] = None
+        self,
+        user: str,
+        *,
+        password: Optional[str] = None,
+        group: Optional[str] = None,
+        logon_token: Optional[HANDLE] = None,
     ) -> None:
         """
         Arguments:
-            user (str): User name of the identity to run the Session's subprocesses under.
-                        This can be either a plain username for a local user, a domain username in down-level logon form,
-                        or a domain's UPN.
-                        ex: localUser, domain\\domainUser, domainUser@domain.com
-            group (Optional[str]): Group name of the identity to run the Session's subprocesses under.
-                         This can be just a group name for a local group, or a domain group in down-level format.
-                         ex: localGroup, domain\\domainGroup
-                         Defaults to the username if not provided.
-            password (Optional[str]): Password of the identity to run the Session's subprocess under.
+            user (str):
+                User name of the identity to run the Session's subprocesses under.
+                This can be either a plain username for a local user, a domain username in down-level logon form,
+                or a domain's UPN.
+                ex: localUser, domain\\domainUser, domainUser@domain.com
+
+            group (Optional[str]):
+                Group name of the identity to run the Session's subprocesses under.
+                This can be just a group name for a local group, or a domain group in down-level format.
+                ex: localGroup, domain\\domainGroup
+                Defaults to the username if not provided.
+
+            password (Optional[str]):
+                Password of the identity to run the Session's subprocess under. This argument is
+                mutually-exclusive with the "logon_token" argument.
+
+            logon_token (Optional[ctypes.wintypes.HANDLE]):
+                Windows logon handle for the target user. This argument is mutually-exclusive with the
+                "password" argument.
         """
         if not is_windows():
             raise RuntimeError("Only available on Windows systems.")
@@ -151,11 +249,17 @@ class WindowsSessionUser(SessionUser):
         if self.is_process_user():
             if password is not None:
                 raise RuntimeError("User is the process owner. Do not provide a password.")
+            # TODO: Add exception if given a token; same user doesn't use tokens.
         else:
             # Note: "" is allowed as that may actually be the password for the user.
             if password is None:
                 raise RuntimeError("Must supply a password. User is not the process owner.")
             self._validate_username_password(user, domain, password)
+            # TODO:
+            #  If running outside Session0:
+            #     - raise exception if given a token; workflow not supported.
+            #  
+            # If we're running within Session0
 
     @staticmethod
     def _is_domain_joined() -> bool:

--- a/src/openjd/sessions/_session_user.py
+++ b/src/openjd/sessions/_session_user.py
@@ -1,7 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import os
-import re
+from typing import Optional, Tuple, Union
+from abc import ABC, abstractmethod
 
 from ._os_checker import is_posix, is_windows
 
@@ -9,44 +10,27 @@ if is_posix():
     import grp
     import pwd
 
-
 if is_windows():
     import win32api
     import win32security
     import win32net
     import win32netcon
-    import win32con
     import pywintypes
     import winerror
     from win32con import LOGON32_LOGON_INTERACTIVE, LOGON32_PROVIDER_DEFAULT
 
-from typing import Optional, Tuple, Union
-
-from abc import ABC, abstractmethod
+    from ._win32._helpers import get_process_user
 
 __all__ = (
     "PosixSessionUser",
     "SessionUser",
     "WindowsSessionUser",
     "BadCredentialsException",
-    "BadUserNameException",
 )
 
 
 class BadCredentialsException(Exception):
     """Exception raised for incorrect username or password."""
-
-    pass
-
-
-class BadUserNameException(Exception):
-    """Exception raised for incorrect username."""
-
-    pass
-
-
-class BadDomainNameException(Exception):
-    """Exception raised for incorrect Domain Name."""
 
     pass
 
@@ -63,7 +47,7 @@ class SessionUser(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_process_user():
+    def _get_process_user():
         """
         Returns the user name of the user running the current process.
         """
@@ -74,7 +58,7 @@ class SessionUser(ABC):
         Returns True if the session user is the user running the current process, else False.
 
         """
-        return self.user == self.get_process_user()
+        return self.user == self._get_process_user()
 
 
 class PosixSessionUser(SessionUser):
@@ -102,7 +86,7 @@ class PosixSessionUser(SessionUser):
         self.group = group if group else grp.getgrgid(os.getegid()).gr_name  # type: ignore
 
     @staticmethod
-    def get_process_user():
+    def _get_process_user():
         """
         Returns the user name of the user running the current process.
         """
@@ -120,7 +104,7 @@ class WindowsSessionUser(SessionUser):
     ex: localUser, domain\\domainUser
     """
 
-    group: Optional[str]
+    group: str
     """
     Group name of the identity to run the Session's subprocesses under.
     This can be just a group name for a local group, or a domain group in down-level logon form.
@@ -144,37 +128,37 @@ class WindowsSessionUser(SessionUser):
             group (Optional[str]): Group name of the identity to run the Session's subprocesses under.
                          This can be just a group name for a local group, or a domain group in down-level format.
                          ex: localGroup, domain\\domainGroup
+                         Defaults to the username if not provided.
             password (Optional[str]): Password of the identity to run the Session's subprocess under.
         """
         if not is_windows():
             raise RuntimeError("Only available on Windows systems.")
 
-        self.group = group
         self.password = password
 
-        if "@" in user and self.is_domain_joined():
+        if "@" in user and self._is_domain_joined():
             user = win32security.TranslateName(
                 user, win32api.NameUserPrincipal, win32api.NameSamCompatible
             )
 
         self.user = user
+        self.group = group if group else user
 
-        domain, username_without_domain = WindowsSessionUser.split_domain_and_username(user)
+        domain, username_without_domain = self._split_domain_and_username(user)
 
-        self.is_valid_username(username_without_domain)
-        if domain:
-            self.is_valid_domain(domain)
-
-        if password is None and not self.is_process_user():
-            raise RuntimeError(
-                "Without passing a password, WindowsSessionUser's user must match the user running Open Job Description."
-            )
-
-        if password is not None:
-            self.validate_username_password(user, domain, password)
+        # Note: We allow user to be the process user to support the case of being able to supply
+        # the group that the process will run under; differing from the user's default group.
+        if self.is_process_user():
+            if password is not None:
+                raise RuntimeError("User is the process owner. Do not provide a password.")
+        else:
+            # Note: "" is allowed as that may actually be the password for the user.
+            if password is None:
+                raise RuntimeError("Must supply a password. User is not the process owner.")
+            self._validate_username_password(user, domain, password)
 
     @staticmethod
-    def is_domain_joined() -> bool:
+    def _is_domain_joined() -> bool:
         """
         Returns True if the machine is joined to a domain, else False.
         """
@@ -182,14 +166,11 @@ class WindowsSessionUser(SessionUser):
         return join_status != win32netcon.NetSetupUnjoined
 
     @staticmethod
-    def get_process_user():
-        """
-        Returns the user name of the user running the current process.
-        """
-        return win32api.GetUserNameEx(win32con.NameSamCompatible)
+    def _get_process_user():
+        return get_process_user()
 
     @staticmethod
-    def split_domain_and_username(user_name_with_domain: str) -> Tuple[Optional[str], str]:
+    def _split_domain_and_username(user_name_with_domain: str) -> Tuple[Optional[str], str]:
         """
         Splits a username with domain into domain and username.
 
@@ -201,12 +182,12 @@ class WindowsSessionUser(SessionUser):
 
         domain = None
         user_name = user_name_with_domain
-        if "\\" in user_name_with_domain and WindowsSessionUser.is_domain_joined():
+        if "\\" in user_name_with_domain and WindowsSessionUser._is_domain_joined():
             domain, user_name = user_name_with_domain.split("\\")
         return domain, user_name
 
     @staticmethod
-    def validate_username_password(
+    def _validate_username_password(
         user_name: str, domain_name: Union[str, None], password: str
     ) -> Optional[bool]:
         """
@@ -237,89 +218,3 @@ class WindowsSessionUser(SessionUser):
             if e.winerror == winerror.ERROR_LOGON_FAILURE:
                 raise BadCredentialsException("The username or password is incorrect.")
             raise
-
-    @staticmethod
-    def is_valid_username(username: str) -> Optional[bool]:
-        """
-        Validates a username based on specific rules.
-        Reference:
-        https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-shell-setup-autologon-username#values
-
-        This function checks if the given username adheres to the following criteria:
-        1. It must be a string.
-        2. Its length should not exceed 256 characters.
-        3. It should not contain any restricted characters ("/[]:|<>+=;,?*%@).
-        4. It should not be the specific name "NONE".
-
-        Parameters:
-            username (str): The username to be validated.
-
-        Returns:
-            Optional[bool]: True if the username is valid according to the above rules, False otherwise.
-
-        Raises:
-            BadUserNameException: If the username doesn't follow the rule.
-        """
-
-        if not isinstance(username, str):
-            raise BadUserNameException(
-                f"Username should be a string, not {type(username).__name__}."
-            )
-
-        if len(username) > 256 or len(username) == 0:
-            raise BadUserNameException("Username must have a length between 1 and 256 characters.")
-
-        # Set of restricted characters
-        restricted_chars = set('"/[]:|<>+=;,?*%@')
-
-        if restricted_chars.intersection(username):
-            raise BadUserNameException(
-                f"Username contains restricted characters {restricted_chars.intersection(username)}. "
-                f"Allowed characters do not include any of {restricted_chars}."
-            )
-
-        if username.upper() == "NONE":
-            raise BadUserNameException("Username cannot be 'NONE'.")
-
-        return True
-
-    @staticmethod
-    def is_valid_domain(domain: str) -> Optional[bool]:
-        """
-        Validates the domain name based on specific criteria.
-        Reference:
-        https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou#dns-domain-names
-
-        This function checks if a given domain name adheres to certain standards:
-        - The domain name must only contain alphabetic characters (A-Z,a-z), numeric characters (0-9),
-          the minus sign (-), and the period (.).
-        - The domain name's length must be between 2 and 255 characters.
-
-        Args:
-            domain (str): The domain name to validate.
-
-        Returns:
-            Optional[bool]: Returns True if the domain name is valid.
-
-        Raises:
-            BadDomainNameException: If the domain name contains disallowed characters or does not meet the
-            length requirements, this exception is raised with a message detailing the validation issue.
-        """
-
-        # Regex pattern to match only allowed characters
-        pattern = r"^[A-Za-z0-9\-.]+$"
-
-        # Check if the string matches the pattern
-        if not re.match(pattern, domain):
-            raise BadDomainNameException(
-                f"Domain name '{domain}' contains disallowed characters."
-                "alphabetic characters (A-Z), numeric characters (0-9), "
-                "the minus sign (-), and the period (.) are only allowed in the domain name."
-            )
-
-        if len(domain) > 255 or len(domain) < 2:
-            raise BadDomainNameException(
-                "Domain name must have a length between 2 and 255 characters."
-            )
-
-        return True

--- a/src/openjd/sessions/_tempdir.py
+++ b/src/openjd/sessions/_tempdir.py
@@ -12,6 +12,9 @@ from ._session_user import PosixSessionUser, SessionUser, WindowsSessionUser
 from ._windows_permission_helper import WindowsPermissionHelper
 from ._os_checker import is_posix, is_windows
 
+if is_windows():
+    from ._win32._helpers import get_process_user
+
 
 def custom_gettempdir(logger: Optional[LoggerAdapter] = None) -> str:
     """
@@ -119,12 +122,9 @@ class TempDir:
             elif is_windows():
                 user = cast(WindowsSessionUser, user)
                 try:
-                    if user.group:
-                        principal_to_permit = user.group
-                    else:
-                        principal_to_permit = user.user
+                    principal_to_permit = user.group
 
-                    process_user = WindowsSessionUser.get_process_user()
+                    process_user = get_process_user()
 
                     WindowsPermissionHelper.set_permissions_full_control(
                         str(self.path), [principal_to_permit, process_user]

--- a/src/openjd/sessions/_win32/__init__.py
+++ b/src/openjd/sessions/_win32/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/src/openjd/sessions/_win32/_helpers.py
+++ b/src/openjd/sessions/_win32/_helpers.py
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import win32api
+import win32con
+
+
+def get_process_user():
+    """
+    Returns the user name of the user running the current process.
+    """
+    return win32api.GetUserNameEx(win32con.NameSamCompatible)

--- a/test/openjd/sessions/test_embedded_files.py
+++ b/test/openjd/sessions/test_embedded_files.py
@@ -112,7 +112,7 @@ class TestEmbeddedFiles:
             assert os.path.exists(result_filename)
             assert result_filename.parent == tmp_path
 
-    @pytest.mark.skipif(os.name != "posix", reason="Posix-specific tests")
+    @pytest.mark.skipif(not is_posix(), reason="posix-specific test")
     class TestMaterializeFilePosix:
         """Tests for EmbeddedFiles._materialize_file() on posix systems.
         Note: Also tests EmbeddedFiles._find_value_prefix() indirectly.
@@ -237,6 +237,7 @@ class TestEmbeddedFiles:
                 result_contents = file.read()
             assert result_contents == testdataresult, "File contents are as expected"
 
+        @pytest.mark.skipif(not is_posix(), reason="posix-specific test")
         @pytest.mark.xfail(
             not has_posix_target_user(),
             reason="Must be running inside of the sudo_environment testing container.",
@@ -279,6 +280,7 @@ class TestEmbeddedFiles:
                 result_contents = file.read()
             assert result_contents == testdata, "File contents are as expected"
 
+        @pytest.mark.skipif(not is_posix(), reason="posix-specific test")
         @pytest.mark.xfail(
             not has_posix_target_user(),
             reason="Must be running inside of the sudo_environment testing container.",
@@ -432,6 +434,7 @@ class TestEmbeddedFiles:
                     assert statinfo.st_mode & stat.S_IRWXG == 0, "Group has no permissions"
                     assert statinfo.st_mode & stat.S_IRWXO == 0, "Others have no permissions"
 
+        @pytest.mark.skipif(not is_posix(), reason="posix-specific test")
         @pytest.mark.xfail(
             not has_posix_target_user(),
             reason="Must be running inside of the sudo_environment testing container.",
@@ -516,6 +519,7 @@ class TestEmbeddedFiles:
                     ), "Group has r/w"
                 assert statinfo.st_mode & stat.S_IRWXO == 0, "Others have no permissions"
 
+        @pytest.mark.skipif(not is_windows(), reason="Windows-specific test")
         @pytest.mark.xfail(
             not has_windows_user(),
             reason=SET_ENV_VARS_MESSAGE,

--- a/test/openjd/sessions/test_runner_base.py
+++ b/test/openjd/sessions/test_runner_base.py
@@ -256,6 +256,7 @@ class TestScriptRunnerBase:
         for key, value in os_env_vars.items():
             assert f"{key} = {value}" in messages
 
+    @pytest.mark.skipif(not is_posix(), reason="posix-only test")
     @pytest.mark.xfail(
         not has_posix_target_user(),
         reason="Must be running inside of the sudo_environment testing container.",
@@ -303,6 +304,7 @@ class TestScriptRunnerBase:
 
         tmpdir.cleanup()
 
+    @pytest.mark.skipif(not is_windows(), reason="Windows-only test")
     @pytest.mark.xfail(
         not has_windows_user(),
         reason=SET_ENV_VARS_MESSAGE,
@@ -317,6 +319,8 @@ class TestScriptRunnerBase:
         # Test that we run the process as a specific desired user
 
         # GIVEN
+        from openjd.sessions._win32._helpers import get_process_user
+
         tmpdir = TempDir(user=windows_user)
         logger = build_logger(queue_handler)
         with TerminatingRunner(
@@ -332,12 +336,13 @@ class TestScriptRunnerBase:
         assert runner.state == ScriptRunnerState.SUCCESS
         assert runner.exit_code == 0
         messages = collect_queue_messages(message_queue)
-        process_user = WindowsSessionUser.get_process_user()
+        process_user = get_process_user()
         assert all([process_user not in message for message in messages])
         assert any(windows_user.user in message for message in messages)
 
         tmpdir.cleanup()
 
+    @pytest.mark.skipif(not is_posix(), reason="posix-specific test")
     @pytest.mark.xfail(
         not has_posix_target_user(),
         reason="Must be running inside of the sudo_environment testing container.",
@@ -392,6 +397,7 @@ class TestScriptRunnerBase:
         assert os.environ[var_name] not in messages
         assert "NOT_PRESENT" in messages
 
+    @pytest.mark.skipif(not is_windows(), reason="Windows-specific test")
     @pytest.mark.xfail(
         not has_windows_user(),
         reason=SET_ENV_VARS_MESSAGE,

--- a/test/openjd/sessions/test_session_user.py
+++ b/test/openjd/sessions/test_session_user.py
@@ -2,8 +2,6 @@
 
 from openjd.sessions._session_user import WindowsSessionUser
 from openjd.sessions._session_user import BadCredentialsException
-from openjd.sessions._session_user import BadUserNameException
-from openjd.sessions._session_user import BadDomainNameException
 from openjd.sessions._os_checker import is_windows
 
 from unittest.mock import patch
@@ -17,21 +15,12 @@ class TestWindowsSessionUser:
         "user",
         ["userA", "domain\\userA"],
     )
+    @patch("openjd.sessions._session_user.WindowsSessionUser._validate_username_password")
     @patch(
         "openjd.sessions._session_user.WindowsSessionUser.is_process_user",
-        return_value=True,
+        return_value=False,
     )
-    @patch(
-        "openjd.sessions._session_user.WindowsSessionUser.is_valid_username",
-        return_value=True,
-    )
-    @patch(
-        "openjd.sessions._session_user.WindowsSessionUser.validate_username_password",
-        return_value=True,
-    )
-    def test_user_not_converted(
-        self, mock_is_process_user, mock_is_valid_username, mock_validate_username_password, user
-    ):
+    def test_user_not_converted(self, mock_is_process_user, mock_validate_username, user):
         windows_session_user = WindowsSessionUser(
             user,
             password="password",
@@ -43,7 +32,7 @@ class TestWindowsSessionUser:
     def test_no_password_impersonation_throws_exception(self):
         with pytest.raises(
             RuntimeError,
-            match="Without passing a password, WindowsSessionUser's user must match the user running Open Job Description.",
+            match="Must supply a password. User is not the process owner.",
         ):
             WindowsSessionUser("nonexistent_user", group="test_group")
 
@@ -54,74 +43,7 @@ class TestWindowsSessionUser:
         ):
             WindowsSessionUser("nonexistent_user", password="abc")
 
-    def test_incorrect_username(self):
-        with pytest.raises(
-            BadUserNameException,
-            match="Username contains restricted characters ",
-        ):
-            WindowsSessionUser("?", password="abc")
-
     def test_split_domain_and_username(self):
-        domain, username = WindowsSessionUser.split_domain_and_username("domain\\user")
+        domain, username = WindowsSessionUser._split_domain_and_username("domain\\user")
         assert domain == "domain"
         assert username == "user"
-
-
-class TestIsValidUsername:
-    def test_valid_username(self):
-        assert WindowsSessionUser.is_valid_username("valid_username")
-
-    def test_non_string_username(self):
-        with pytest.raises(BadUserNameException, match="Username should be a string, not"):
-            WindowsSessionUser.is_valid_username(123)  # type: ignore
-
-    def test_too_long_username(self):
-        with pytest.raises(
-            BadUserNameException, match="Username must have a length between 1 and 256 characters"
-        ):
-            WindowsSessionUser.is_valid_username("a" * 257)
-
-    def test_empty_username(self):
-        with pytest.raises(
-            BadUserNameException, match="Username must have a length between 1 and 256 characters"
-        ):
-            WindowsSessionUser.is_valid_username("")
-
-    def test_username_with_restricted_chars(self):
-        with pytest.raises(BadUserNameException, match="Username contains restricted characters"):
-            WindowsSessionUser.is_valid_username("/username")
-
-    def test_username_none(self):
-        with pytest.raises(BadUserNameException, match="Username cannot be 'NONE'"):
-            WindowsSessionUser.is_valid_username("NONE")
-
-
-class TestIsValidDomainName:
-    def test_valid_domain(self):
-        assert WindowsSessionUser.is_valid_domain("example.com")
-        assert WindowsSessionUser.is_valid_domain("sub-domain.domain.org")
-        assert WindowsSessionUser.is_valid_domain("example")
-        assert WindowsSessionUser.is_valid_domain("domain1")
-        assert WindowsSessionUser.is_valid_domain("SUBDOMAIN.DOMAIN")
-
-    def test_domain_with_disallowed_characters(self):
-        with pytest.raises(
-            BadDomainNameException,
-            match="Domain name 'example.com!' contains disallowed characters",
-        ):
-            WindowsSessionUser.is_valid_domain("example.com!")
-
-    def test_domain_too_short(self):
-        with pytest.raises(
-            BadDomainNameException,
-            match="Domain name must have a length between 2 and 255 characters.",
-        ):
-            WindowsSessionUser.is_valid_domain("e")
-
-    def test_domain_too_long(self):
-        long_domain = "a" * 256
-        with pytest.raises(
-            BadDomainNameException,
-            match="Domain name must have a length between 2 and 255 characters.",
-        ):
-            WindowsSessionUser.is_valid_domain(long_domain)

--- a/test/openjd/sessions/test_tempdir.py
+++ b/test/openjd/sessions/test_tempdir.py
@@ -154,6 +154,8 @@ class TestTempDirWindows:
             str(tempdir.path / "child_dir" / "grandchild_file"), windows_user.group
         )
 
+    # Mock is_process_user to get around the password requirement, since we're just testing
+    # file permissions
     @patch("openjd.sessions.WindowsSessionUser.is_process_user", return_value=True)
     def test_windows_user_without_group_permits_user(self, mock_user_match):
         # GIVEN
@@ -254,6 +256,7 @@ class TestTempDirPosixUser:
             TempDir(user=posix_disjoint_user)
 
 
+@pytest.mark.skipif(not is_windows(), reason="Windows-specific test")
 @pytest.mark.xfail(not has_windows_user(), reason=SET_ENV_VARS_MESSAGE)
 @pytest.mark.usefixtures("windows_user")
 class TestTempDirWindowsUser:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The current impersonation code for Windows does not work when running in Session 0 (i.e. inside of an OS Service). We need to fix that. This draft PR has some potential ways to tackle solving this; intended for discussion.

(( Only look at the recent commit -- basically the giant comment block & TODOs in the `WindowsSessionUser` class; this is on top of https://github.com/OpenJobDescription/openjd-sessions-for-python/pull/91 which hasn't merged yet ))

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*