### PR TITLE
feat!: remove group property from WindowsSessionUser

### DIFF
--- a/src/openjd/sessions/_embedded_files.py
+++ b/src/openjd/sessions/_embedded_files.py
@@ -77,8 +77,10 @@ def write_file_for_user(
         if user is not None:
             user = cast(WindowsSessionUser, user)
             process_user = get_process_user()
-            WindowsPermissionHelper.set_permissions_full_control(
-                str(filename), [process_user, user.user]
+            WindowsPermissionHelper.set_permissions(
+                str(filename),
+                principals_full_control=[process_user],
+                principals_modify_access=[user.user],
             )
 
 

--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -162,6 +162,23 @@ class Session(object):
     module's LOG Logger at log level INFO. The LogRecords sent to the log have an
     extra attribute named "session_id" whose value is the session_id that was passed
     to the constructor of the Session.
+
+    Each Session has its own temporary working directory, referred to as the Session
+    Working Directory. Instantiating this class creates this directory for the duration
+    of the Session, and you are expected to call the cleanup() method on your Session
+    to delete that directory when done (this is done automatically if using the Session
+    as a context manager).
+    On POSIX:
+    - The Session Working Directory's owner is the process owner.
+    - If a PosixSessionUser is provided, then the group of that user is the group owner
+      of the the directory.
+    On Windows:
+    - All files and directories within the Session Working Directory inherit the
+      directory's ACL.
+    - The Session Working Directory's ACL is set so that the process owner has full
+      control
+    - If a WindowsSessionUser is provided then the user within that SessionUser
+      is also given Modify access.
     """
 
     _state: SessionState

--- a/src/openjd/sessions/_session_user.py
+++ b/src/openjd/sessions/_session_user.py
@@ -112,22 +112,22 @@ class WindowsSessionUser(SessionUser):
        includes a logon session obtained by ssh-ing into the host), then you must instantiate this
        class with a username + logon_token; providing a password is not allowed in Session 0. To
        create a logon_token, you will want to look in to the LogonUser family of Win32 system APIs.
+
+    The user provided in this class directly influences the Directory ACL of the Session Working
+    Directory that is created. The created directory:
+    1. Has Full Control by the owner of the calling process; and
+    2. Has Modify access by the provided user.
+    The Session working directory will also be set so that all child directories and files
+    inherit these permissions.
     """
 
-    __slots__ = ("user", "group", "password", "logon_token")
+    __slots__ = ("user", "password", "logon_token")
 
     user: str
     """
     User name of the identity to run the Session's subprocesses under.
     This can be either a plain username for a local user or a domain username in down-level logon form
     ex: localUser, domain\\domainUser
-    """
-
-    group: str
-    """
-    Group name of the identity to run the Session's subprocesses under.
-    This can be just a group name for a local group, or a domain group in down-level logon form.
-    ex: localGroup, domain\\domainGroup
     """
 
     password: Optional[str]
@@ -146,7 +146,6 @@ class WindowsSessionUser(SessionUser):
         self,
         user: str,
         *,
-        group: Optional[str] = None,
         password: Optional[str] = None,
         logon_token: Optional[HANDLE] = None,
     ) -> None:
@@ -157,12 +156,6 @@ class WindowsSessionUser(SessionUser):
                 This can be either a plain username for a local user, a domain username in down-level logon form,
                 or a domain's UPN.
                 ex: localUser, domain\\domainUser, domainUser@domain.com
-
-            group (Optional[str]):
-                Group name of the identity to run the Session's subprocesses under.
-                This can be just a group name for a local group, or a domain group in down-level format.
-                ex: localGroup, domain\\domainGroup
-                Defaults to the username if not provided.
 
             password (Optional[str]):
                 Password of the identity to run the Session's subprocess under. This argument is mutually-exclusive with the
@@ -184,7 +177,6 @@ class WindowsSessionUser(SessionUser):
             )
 
         self.user = user
-        self.group = group if group else user
 
         domain, username_without_domain = self._split_domain_and_username(user)
 

--- a/src/openjd/sessions/_tempdir.py
+++ b/src/openjd/sessions/_tempdir.py
@@ -122,12 +122,10 @@ class TempDir:
             elif is_windows():
                 user = cast(WindowsSessionUser, user)
                 try:
-                    principal_to_permit = user.group
-
-                    process_user = get_process_user()
-
-                    WindowsPermissionHelper.set_permissions_full_control(
-                        str(self.path), [principal_to_permit, process_user]
+                    WindowsPermissionHelper.set_permissions(
+                        str(self.path),
+                        principals_full_control=[get_process_user()],
+                        principals_modify_access=[user.user],
                     )
                 except Exception as err:
                     raise RuntimeError(

--- a/test/openjd/sessions/test_embedded_files.py
+++ b/test/openjd/sessions/test_embedded_files.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 from openjd.sessions._os_checker import is_posix, is_windows
 import pytest
 
-from utils.windows_acl_helper import principal_has_full_control_of_object
+from utils.windows_acl_helper import MODIFY_READ_WRITE_MASK, principal_has_access_to_object
 
 from openjd.model import SymbolTable
 from openjd.model.v2023_09 import DataString as DataString_2023_09
@@ -358,9 +358,9 @@ class TestEmbeddedFiles:
 
             # THEN
             assert os.path.exists(filename)
-            assert principal_has_full_control_of_object(
-                str(filename), windows_user.user
-            ), "Windows user has full control"
+            assert principal_has_access_to_object(
+                str(filename), windows_user.user, MODIFY_READ_WRITE_MASK
+            ), "Windows user has access"
             with open(filename, "r") as file:
                 result_contents = file.read()
             assert result_contents == testdata, "File contents are as expected"
@@ -588,9 +588,9 @@ class TestEmbeddedFiles:
                     result_contents = file.read()
                 assert result_contents == data.data, "File contents are as expected"
                 # Check file permissions
-                assert principal_has_full_control_of_object(
-                    filename, windows_user.user
-                ), "Windows user has full control"
+                assert principal_has_access_to_object(
+                    filename, windows_user.user, MODIFY_READ_WRITE_MASK
+                ), "Windows user has access"
 
         def test_resolves_symbols(self, tmp_path: Path) -> None:
             # Tests that the set of files can reference themselves and each other

--- a/test/openjd/sessions/test_session.py
+++ b/test/openjd/sessions/test_session.py
@@ -371,10 +371,14 @@ class TestSessionInitialization:
         with open(working_dir_file_path, "w") as f:
             f.write("File content")
 
-        WindowsPermissionHelper.set_permissions_full_control(subdir_path, [windows_user.user])
-        WindowsPermissionHelper.set_permissions_full_control(subdir_file_path, [windows_user.user])
-        WindowsPermissionHelper.set_permissions_full_control(
-            working_dir_file_path, [windows_user.user]
+        WindowsPermissionHelper.set_permissions(
+            subdir_path, principals_full_control=[windows_user.user]
+        )
+        WindowsPermissionHelper.set_permissions(
+            subdir_file_path, principals_full_control=[windows_user.user]
+        )
+        WindowsPermissionHelper.set_permissions(
+            working_dir_file_path, principals_full_control=[windows_user.user]
         )
 
         session.cleanup()

--- a/test/openjd/sessions/test_session_user.py
+++ b/test/openjd/sessions/test_session_user.py
@@ -28,11 +28,7 @@ class TestWindowsSessionUser:
         return_value=False,
     )
     def test_user_not_converted(self, mock_is_process_user, mock_validate_username, user):
-        windows_session_user = WindowsSessionUser(
-            user,
-            password="password",
-            group="test_group",
-        )
+        windows_session_user = WindowsSessionUser(user, password="password")
 
         assert windows_session_user.user == user
 
@@ -41,7 +37,7 @@ class TestWindowsSessionUser:
             RuntimeError,
             match="Must supply a password or logon token. User is not the process owner.",
         ):
-            WindowsSessionUser("nonexistent_user", group="test_group")
+            WindowsSessionUser("nonexistent_user")
 
     @pytest.mark.skipif(
         tests_are_in_windows_session_0(),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The design of the WindowsSessionUser is currently heavily influenced by the posix design in that it requires a Group for setting directory ACLs of the Session Working Directory. Windows has finer grained ACLs for controlling access to files and directories, so we should be exposing an interface that works better with that instead.

### What was the solution? (How)

We no longer accept a group in the WindowsSessionUser. The Session Working Directory's ACLS are now set to:

1. Process owner -- full control
2. Given user -- modify/read/write/execute

### What is the impact of this change?

An interface that is, hopefully, more natural for Windows use-cases.

### How was this change tested?

Unit tests were updated; they all actually modify ACLs and verify them.

I also did up a quick test using a python script identical to the permissions change to set the permissions on a temp directory on my workstation, and then verified that the permissions are exactly as expected:

![Basic Permissions](https://github.com/OpenJobDescription/openjd-sessions-for-python/assets/53624638/190e978b-d534-4179-8382-5cf7c0084ac0)
![Advanced Permissions](https://github.com/OpenJobDescription/openjd-sessions-for-python/assets/53624638/215ae81e-79a9-4cf0-a312-6fcea5764c1b)



### Was this change documented?

In the docstrings for the relevant class, yes.

### Is this a breaking change?

**BREAKING CHANGE**
The "group" property of WindowsSessionUser has been removed.


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*