### PR TITLE
chore: Notify windows subprocess directly

### DIFF
--- a/src/openjd/sessions/_scripts/_windows/_signal_win_subprocess.py
+++ b/src/openjd/sessions/_scripts/_windows/_signal_win_subprocess.py
@@ -50,8 +50,6 @@ def signal_process(pgid: int):
     # We send CTRL-BREAK as handler for it cannnot be disabled.
     # https://learn.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals
 
-    if not kernel32.GenerateConsoleCtrlEvent(CTRL_C_EVENT, pgid):
-        raise ctypes.WinError()
     if not kernel32.GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pgid):
         raise ctypes.WinError()
 

--- a/src/openjd/sessions/_subprocess.py
+++ b/src/openjd/sessions/_subprocess.py
@@ -5,8 +5,9 @@ import shlex
 from ._os_checker import is_posix, is_windows
 
 if is_windows():
-    from subprocess import CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW  # type: ignore
+    from subprocess import CREATE_NEW_PROCESS_GROUP  # type: ignore
     from ._win32._popen_as_user import PopenWindowsAsUser  # type: ignore
+    from ._scripts._windows._signal_win_subprocess import signal_process  # type: ignore
     from ._windows_process_killer import kill_windows_process_tree
 from typing import Any
 from threading import Event
@@ -15,7 +16,7 @@ from subprocess import DEVNULL, PIPE, STDOUT, Popen, list2cmdline, run
 from typing import Callable, Optional, Sequence, cast
 from pathlib import Path
 from datetime import timedelta
-import sys
+import signal
 
 from ._session_user import PosixSessionUser, WindowsSessionUser, SessionUser
 
@@ -34,10 +35,6 @@ __all__ = ("LoggingSubprocess",)
 
 POSIX_SIGNAL_SUBPROC_SCRIPT_PATH = (
     Path(__file__).parent / "_scripts" / "_posix" / "_signal_subprocess.sh"
-)
-
-WINDOWS_SIGNAL_SUBPROC_SCRIPT_PATH = (
-    Path(__file__).parent / "_scripts" / "_windows" / "_signal_win_subprocess.py"
 )
 
 LOG_LINE_MAX_LENGTH = 64 * 1000  # Start out with 64 KB, can increase if needed
@@ -358,21 +355,9 @@ class LoggingSubprocess(object):
         # https://stackoverflow.com/questions/35772001/how-to-handle-a-signal-sigint-on-a-windows-os-machine/35792192#35792192
         self._logger.info(f"INTERRUPT: Sending CTRL_BREAK_EVENT to {self._process.pid}")
 
-        # _process will be running in new console, we run another process to attach to it and send signal
-        cmd = [
-            sys.executable,
-            str(WINDOWS_SIGNAL_SUBPROC_SCRIPT_PATH),
-            str(self._process.pid),
-        ]
-        result = run(
-            cmd,
-            stdout=PIPE,
-            stderr=STDOUT,
-            stdin=DEVNULL,
-            creationflags=CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
-        )
-        if result.returncode != 0:
-            self._logger.warning(
-                f"Failed to send signal 'CTRL_BREAK_EVENT' to subprocess {self._process.pid}: %s",
-                result.stdout.decode("utf-8"),
-            )
+        if self._user is None:
+            # _process runs in current console if current user, we can signal it directly
+            self._process.send_signal(signal.CTRL_BREAK_EVENT)  # type: ignore
+        else:
+            # otherwise we call signal_process to attach to the _process console in order to signal it
+            signal_process(self._process.pid)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Notify signal for a windows process was sent from the _signal_win_subprocess.py script run as a subprocess. We wish to remove the need to run it as another process.

### What was the solution? (How)
Run the commands directly from OJD.

### What is the impact of this change?
One less subprocess run by OJD

### How was this change tested?
Unit tests

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*