### PR TITLE
fix: Failing to parse openjd_env and openjd_unset_env should fail session action

### DIFF
--- a/src/openjd/sessions/_runner_env_script.py
+++ b/src/openjd/sessions/_runner_env_script.py
@@ -166,7 +166,9 @@ class EnvironmentScriptRunner(ScriptRunnerBase):
 
         self._run_env_action(self._environment_script.actions.onExit)
 
-    def cancel(self, *, time_limit: Optional[timedelta] = None) -> None:
+    def cancel(
+        self, *, time_limit: Optional[timedelta] = None, mark_action_failed: bool = False
+    ) -> None:
         if self._action is None:
             # Nothing to do.
             return
@@ -194,4 +196,4 @@ class EnvironmentScriptRunner(ScriptRunnerBase):
                 )
 
         # Note: If the given time_limit is less than that in the method, then the time_limit will be what's used.
-        self._cancel(method, time_limit)
+        self._cancel(method, time_limit, mark_action_failed)

--- a/src/openjd/sessions/_runner_step_script.py
+++ b/src/openjd/sessions/_runner_step_script.py
@@ -121,7 +121,9 @@ class StepScriptRunner(ScriptRunnerBase):
         # Construct the command by evalutating the format strings in the command
         self._run_action(self._script.actions.onRun, symtab)
 
-    def cancel(self, *, time_limit: Optional[timedelta] = None) -> None:
+    def cancel(
+        self, *, time_limit: Optional[timedelta] = None, mark_action_failed: bool = False
+    ) -> None:
         # For the type checker.
         assert isinstance(self._script, StepScript_2023_09)
 
@@ -145,4 +147,4 @@ class StepScriptRunner(ScriptRunnerBase):
                 )
 
         # Note: If the given time_limit is less than that in the method, then the time_limit will be what's used.
-        self._cancel(method, time_limit)
+        self._cancel(method, time_limit, mark_action_failed)

--- a/test/openjd/sessions/test_runner_base.py
+++ b/test/openjd/sessions/test_runner_base.py
@@ -48,13 +48,17 @@ from .conftest import (
 class TerminatingRunner(ScriptRunnerBase):
     _cancel_called = False
 
-    def cancel(self, *, time_limit: Optional[timedelta] = None) -> None:
+    def cancel(
+        self, *, time_limit: Optional[timedelta] = None, mark_action_failed: bool = False
+    ) -> None:
         self._cancel_called = True
         self._cancel(TerminateCancelMethod())
 
 
 class NotifyingRunner(ScriptRunnerBase):
-    def cancel(self, *, time_limit: Optional[timedelta] = None) -> None:
+    def cancel(
+        self, *, time_limit: Optional[timedelta] = None, mark_action_failed: bool = False
+    ) -> None:
         self._cancel_called_at = datetime.utcnow()
         if time_limit is None:
             self._cancel(NotifyCancelMethod(timedelta(seconds=2)))


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When the stdout handlers in OpenJD fail to process a message, the error is logged but does not fail the action. This is intended behavior for non-functional messages (e.g. ``openjd_status`` and ``openjd_progress``). However, for functional messages such as ``openjd_env`` or ``openjd_unset_env`` which sets an environment variable in the session, we should fail the session when the stdout handler fails to process these messages since this could have adverse effects on the session action.

### What was the solution? (How)
Cancel the ongoing action when an error occurs in ``openjd_env`` or ``openjd_unset_env`` and mark the action as ``FAILED`` when the callback is sent to the session. Also to support customers an additional regex for "almost" matching env or unset_env (like whitespaces or casing issues) is also detected and cancels the action, marks it as failed back to the session.

### What is the impact of this change?
Better error handling for customers so they know if setting an env variable fails instead of hiding the error.

### How was this change tested?
Modified and ran existing unit tests. Added more tests for testing that the callback sent to the calling session marks the action as ``FAILED``
### Was this change documented?
N/A

### Is this a breaking change?
No, fix!

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*