### PR TITLE
feat: resolve windows command location prior to run

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -8,7 +8,7 @@ sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test}"
 typing = "mypy {args:src test}"
 style = [
-  "ruff {args:.}",
+  "ruff check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [

--- a/src/openjd/sessions/_scripts/_windows/_signal_win_subprocess.py
+++ b/src/openjd/sessions/_scripts/_windows/_signal_win_subprocess.py
@@ -50,8 +50,9 @@ def signal_process(pgid: int):
     # We send CTRL-BREAK as handler for it cannnot be disabled.
     # https://learn.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals
 
-    if not kernel32.GenerateConsoleCtrlEvent(CTRL_C_EVENT, pgid):
-        raise ctypes.WinError()
+    # We only send CTRL-BREAK
+    # if not kernel32.GenerateConsoleCtrlEvent(CTRL_C_EVENT, pgid):
+    #     raise ctypes.WinError()
     if not kernel32.GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pgid):
         raise ctypes.WinError()
 

--- a/src/openjd/sessions/_win32/_locate_executable.py
+++ b/src/openjd/sessions/_win32/_locate_executable.py
@@ -1,0 +1,134 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import shutil
+from logging import INFO, LoggerAdapter, getLogger
+from logging.handlers import QueueHandler
+from pathlib import Path
+from queue import Empty, SimpleQueue
+from threading import Lock
+from typing import Optional, Sequence
+
+from .._session_user import SessionUser
+from .._subprocess import LoggingSubprocess
+
+_internal_logger_lock = Lock()
+_internal_logger = getLogger("openjd_sessions_runner_base_internal_logger")
+_internal_logger_adapter = LoggerAdapter(_internal_logger, extra=dict())
+_internal_logger.setLevel(INFO)
+_internal_logger.propagate = False
+_internal_logger_queue: SimpleQueue = SimpleQueue()
+_internal_logger.addHandler(QueueHandler(_internal_logger_queue))
+
+
+def locate_windows_executable(
+    args: Sequence[str],
+    user: Optional[SessionUser],
+    os_env_vars: Optional[dict[str, Optional[str]]],
+    working_dir: str,
+) -> Sequence[str]:
+    cmd_path = Path(args[0])
+    if cmd_path.is_absolute():
+        # If it's an absolute path (e.g. C:\Foo\Bar.exe or C:\Foo\Bar) then we just return
+        # and leave it up to the OS to resolve the executable's extention.
+
+        # TODO: Do we actually still want to do the find as a check to see if the command exists &
+        # is executable? This would catch stuff like 'c:\Foo\test.ps1' as a command (which fails)
+        return args
+
+    return_args = list(args)
+    if user is None:
+        return_args[0] = _locate_for_same_user(cmd_path, os_env_vars, working_dir)
+    else:
+        return_args[0] = _locate_for_other_user(cmd_path, os_env_vars, working_dir, user)
+    return return_args
+
+
+def _locate_for_same_user(
+    command: Path, os_env_vars: Optional[dict[str, Optional[str]]], working_dir: str
+) -> str:
+    # Running as the same user, so we can use shutil.which.
+    path_var: Optional[str] = None
+    if os_env_vars:
+        env_var_keys = {k.lower(): k for k in os_env_vars}
+        path_var = os_env_vars.get(env_var_keys["path"]) if "path" in env_var_keys else None
+    if path_var is None:
+        path_var = os.environ.get("PATH", "")
+    path_var = "%s;%s" % (working_dir, path_var)
+    exe = str(shutil.which(str(command), path=path_var))
+    if not exe:
+        raise RuntimeError("Could not find executable file: %s" % command)
+    return exe
+
+
+def _locate_for_other_user(
+    command: Path,
+    os_env_vars: Optional[dict[str, Optional[str]]],
+    working_dir: str,
+    user: SessionUser,
+) -> str:
+    # Running as a potentially different user, so it's possible that
+    # this process doesn't have read access to the executable file's location.
+    # Thus, we need to rely on running a subprocess as the user to be able
+    # to find the executable.
+
+    if len(command.parts) > 1:
+        # Windows cannot find executables by relative location
+        # i.e. where "dir\test.bat"
+        #
+        # Even if that worked, we'd have to prepend the relative part of the command
+        # to the path and then search for only the command.name. But, we don't generally
+        # have the user's PATH env var value.
+        #
+        # So, for both of those reasons we just return the command and let the action fail out
+        # naturally.
+        return str(command)
+
+    # Prevent issues that might arise by having multiple Actions trying to start up
+    # concurrently -- grab a lock.
+    with _internal_logger_lock:
+        # Drain the message queue to ensure nothing remains from previous runs.
+        try:
+            while True:
+                _internal_logger_queue.get(block=False)
+        except Empty:
+            pass  # Will happen when the queue is fully empty
+        process = LoggingSubprocess(
+            logger=_internal_logger_adapter,
+            args=[
+                str(Path(os.environ.get("WINDIR", r"C:\Windows")) / "System32" / "cmd.exe"),
+                "/C",
+                # Command injection here is possible, but it's irrelevant. The command is running
+                # as the given user. No need for an attacker to be fancy here, they could just run
+                # the desired attack command directly in the job template.
+                "where %s" % command,
+            ],
+            user=user,
+            os_env_vars=os_env_vars,
+            working_dir=str(working_dir),
+        )
+        process.run()  # blocking call
+        if process.exit_code != 0:
+            raise RuntimeError("Could not find executable file: %s" % command)
+
+        # We're seeing random errors when trying to run an Action's command immediately after this
+        # outside of Session 0; theory is that maybe this has something to do with running two
+        # CreateProcessWithLogonW calls back-to-back with little time inbetween. So, explicitly
+        # delete the process object to try to force some cleanup of handles that maybe help the
+        # profile get unloaded. (this seems like it might be doing the trick)
+        # Error:
+        #  [WinError 1018] Illegal operation attempted on a registry key that has been marked for deletion
+        del process
+
+        # Parse the output
+        try:
+            while True:
+                record = _internal_logger_queue.get(block=False)
+                message = record.getMessage()
+                if "Output:" in message:
+                    break
+            exe_record = _internal_logger_queue.get(block=False)
+            # The first line of output from 'where' is the location of the command
+            return exe_record.getMessage()
+        except Empty:
+            raise RuntimeError("Could not find executable file: %s" % command) from None  #

--- a/test/openjd/sessions/test_runner_base.py
+++ b/test/openjd/sessions/test_runner_base.py
@@ -407,6 +407,40 @@ class TestScriptRunnerBase:
         not has_windows_user(),
         reason=WIN_SET_TEST_ENV_VARS_MESSAGE,
     )
+    @pytest.mark.timeout(90)
+    def test_failed_run_as_windows_user(
+        self,
+        windows_user: WindowsSessionUser,
+        message_queue: SimpleQueue,
+        queue_handler: QueueHandler,
+    ) -> None:
+        # Test we fail properly when given a command that does not exist
+
+        # GIVEN
+        tmpdir = TempDir(user=windows_user)
+        logger = build_logger(queue_handler)
+        with TerminatingRunner(
+            logger=logger, session_working_directory=tmpdir.path, user=windows_user
+        ) as runner:
+            # WHEN
+            runner._run(["test_not_a_command"])
+            # Wait until the process exits.
+            while runner.state == ScriptRunnerState.RUNNING:
+                time.sleep(0.1)
+
+        # THEN
+        assert runner.state == ScriptRunnerState.FAILED
+        assert runner.exit_code is None
+        messages = collect_queue_messages(message_queue)
+        assert messages == ["openjd_fail: Could not find executable file: test_not_a_command"]
+
+        tmpdir.cleanup()
+
+    @pytest.mark.skipif(not is_windows(), reason="Windows-only test")
+    @pytest.mark.xfail(
+        not has_windows_user(),
+        reason=WIN_SET_TEST_ENV_VARS_MESSAGE,
+    )
     @pytest.mark.timeout(30)
     @pytest.mark.usefixtures("message_queue", "queue_handler", "windows_user")
     def test_run_as_windows_user_with_env_vars(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When running a subprocess on Windows without a shell, as we do, there is no guarantee that Windows will find the and run the first instance of the command executable on the user's PATH. We've seen this manifest as a user having mingw bash installed and first in their PATH, but running an action with command "bash" ends up finding the WSL bash executable instead. To ensure that the correct command is run you must provide the full path to the command.

### What was the solution? (How)

It's multifacted. The main factor is that the user that's running the main process may not be the same user that an Action is running as, and thus may have different default PATH and may not even be able to access/list the same files/directories as the Action user. So, we:

1. If running the Action as the same user as the main process, then we use shutil.which() to resolve the command's full path, and then run that. Taking care to prepend the Session Working Dir to the PATH if an openjd_env has previously been done that sets the PATH.

2. If running the Action as a different user, then we run "cmd /C 'which <command name>'" and parse the output to figure out where the command is located. We run this command with the same env vars and working directory as the Action will be run with.

There are limitations of this approach, but it seems to be the best that I can currently figure out. Notably, if a command is a relative path then 'where' cannot resolve the full command path, so we just have to pass the command through as relative and hope for the best.

### What is the impact of this change?

Users running Actions on Windows should have a higher probability of a command running the executable that they are expecting to run if providing the command as simply the command name (e.g. "bash").

### How was this change tested?

I added unit tests, and ran them both in an interactive login as well as a Session 0 logon (via ssh) as per the developer instructions.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*