### PR TITLE
ci: add PyPI publish job to publish workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -16,6 +16,32 @@ jobs:
     name: Publish Release
     permissions:
       id-token: write
-      contents: read
+      contents: write
     uses: OpenJobDescription/.github/.github/workflows/reusable_publish.yml@mainline
     secrets: inherit
+  # PyPI does not support reusable workflows yet
+  # # See https://github.com/pypi/warehouse/issues/11096
+  PublishToPyPI:
+    needs: Publish
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade hatch
+      - name: Build
+        run: hatch -v build
+      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
PyPI publishing does not support reusable workflows, there is an open issue to add support:

https://github.com/pypi/warehouse/issues/11096

For now we need to keep publishing to pypi as a job in the publish workflow file of each repository so that it can authenticate to publish.

The Release job in the reusable publish workflow requires contents write permissons.

https://github.com/OpenJobDescription/.github/blob/mainline/.github/workflows/reusable_publish.yml#L35

### What was the solution? (How)
* Add a job to publish to PyPI in the release_publish.yml workflow
* Add write permissions to the calling workflow.


### What is the impact of this change?
Move PyPI publishing job back to each repository instead of using a reusable workflow

### How was this change tested?
Tested in a developer github account 

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*