### PR TITLE
revert: ensure process exit code is a 32-bit signed integer

### DIFF
--- a/src/openjd/sessions/_subprocess.py
+++ b/src/openjd/sessions/_subprocess.py
@@ -43,15 +43,6 @@ WINDOWS_SIGNAL_SUBPROC_SCRIPT_PATH = (
 LOG_LINE_MAX_LENGTH = 64 * 1000  # Start out with 64 KB, can increase if needed
 
 
-def _exit_code_to_32bit_signed(exitcode: Optional[int]) -> Optional[int]:
-    # Workaround to ensure that the process exit code is returned in range of
-    # a 32-bit signed integer.
-    if exitcode is None:
-        return None
-    as_uint32_bytes = (exitcode & 0xFFFFFFFF).to_bytes(4, "big", signed=False)
-    return int.from_bytes(as_uint32_bytes, "big", signed=True)
-
-
 class LoggingSubprocess(object):
     """A process whose stdout/stderr lines are sent to a given Logger."""
 
@@ -110,15 +101,15 @@ class LoggingSubprocess(object):
     def exit_code(self) -> Optional[int]:
         """
         :return: None if the process has not yet exited. Otherwise, it returns the exit code of the
-            process. This will always be in range of a 32-bit signed integer.
+            process
         """
         # The process.wait() in the run() method ensures that the returncode
         # has been set once the subprocess has completed running. Don't poll here...
         # we only want to make the returncode available after the run method has
         # completed its work.
         if self._process is not None:
-            return _exit_code_to_32bit_signed(self._process.returncode)
-        return _exit_code_to_32bit_signed(self._returncode)
+            return self._process.returncode
+        return self._returncode
 
     @property
     def is_running(self) -> bool:

--- a/test/openjd/sessions/test_subprocess.py
+++ b/test/openjd/sessions/test_subprocess.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from queue import SimpleQueue
 from unittest.mock import MagicMock
 import pytest
-from typing import Optional
 
 from openjd.sessions._os_checker import is_posix, is_windows
 from openjd.sessions._session_user import PosixSessionUser, WindowsSessionUser
@@ -56,70 +55,6 @@ class TestLoggingSubprocessSameUser:
         assert subproc.pid is None
         assert subproc.exit_code is None
         assert not subproc.is_running
-
-    @pytest.mark.parametrize(
-        "exitcode, expected_result",
-        [
-            pytest.param(None, None, id="None"),
-            pytest.param(0, 0, id="Zero"),
-            pytest.param(0x7FFFFFFF, 0x7FFFFFFF, id="maxint"),
-            pytest.param(-2147483648, -2147483648, id="minint_decimal"),
-            pytest.param(0x80000000, -2147483648, id="minint_hex"),
-            pytest.param(0xFFFD0000, -196608, id="out-of-range-32bit"),
-            pytest.param(0xFFFFFFFD0000, -196608, id="out-of-range-big"),
-        ],
-    )
-    def test_return_code_in_range(
-        self, exitcode: Optional[int], expected_result: Optional[int]
-    ) -> None:
-        # We've seen process exit codes that are not properly converted from 32-bit to signed integer.
-        # Ensure that the process exit code is always in range of a 32-bit signed integer.
-
-        # GIVEN
-        subproc = LoggingSubprocess(
-            logger=MagicMock(),
-            args=[sys.executable, "-c", 'print("Test")'],
-        )
-        subproc._returncode = exitcode
-
-        # WHEN
-        result = subproc.exit_code
-
-        # THEN
-        assert result == expected_result
-
-    @pytest.mark.parametrize(
-        "exitcode, expected_result",
-        [
-            pytest.param(None, None, id="None"),
-            pytest.param(0, 0, id="Zero"),
-            pytest.param(0x7FFFFFFF, 0x7FFFFFFF, id="maxint"),
-            pytest.param(-2147483648, -2147483648, id="minint_decimal"),
-            pytest.param(0x80000000, -2147483648, id="minint_hex"),
-            pytest.param(0xFFFD0000, -196608, id="out-of-range-32bit"),
-            pytest.param(0xFFFFFFFD0000, -196608, id="out-of-range-big"),
-        ],
-    )
-    def test_return_code_in_range_from_process(
-        self, exitcode: Optional[int], expected_result: Optional[int]
-    ) -> None:
-        # We've seen process exit codes that are not properly converted from 32-bit to signed integer.
-        # Ensure that the process exit code is always in range of a 32-bit signed integer when fetched directly
-        # from an active Popen object.
-
-        # GIVEN
-        subproc = LoggingSubprocess(
-            logger=MagicMock(),
-            args=[sys.executable, "-c", 'print("Test")'],
-        )
-        subproc._process = MagicMock()
-        subproc._process.returncode = exitcode
-
-        # WHEN
-        result = subproc.exit_code
-
-        # THEN
-        assert result == expected_result
 
     @pytest.mark.parametrize("exitcode", [0, 1])
     def test_basic_operation(


### PR DESCRIPTION
Reverts OpenJobDescription/openjd-sessions-for-python#148

.NET defines a [process exit code as a signed 32-bit integer](https://learn.microsoft.com/en-us/dotnet/api/system.environment.exitcode?view=net-8.0). But, Win32 APIs define the exit code as a [DWORD which is a 32-bit unsigned integer](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/262627d8-3418-4627-9218-4ffe110850b2). e.g. [GetExitCodeProcess](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess), [ExitProcess](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-exitprocess), and [TerminateProcess](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-terminateprocess)

POSIX defines the exit code as 8 bit unsigned: https://pubs.opengroup.org/onlinepubs/009695399/functions/exit.html
"only the least significant 8 bits (that is, status & 0377) shall be available to a waiting parent process."

We should follow the expectation set by Python and follow the low-level Win32 API and posix spec. Let the LoggingSubprocess return 32-bit unsigned integers as the exit code.