### PR TITLE
feat: log process return code on process exit

### DIFF
--- a/src/openjd/sessions/_subprocess.py
+++ b/src/openjd/sessions/_subprocess.py
@@ -182,6 +182,21 @@ class LoggingSubprocess(object):
 
             self._process.wait()
             self._returncode = self._process.returncode
+            if self._returncode is not None:
+                # Print out the signed representation of returncodes that would be negative as a 32-bit signed integer
+                if self._returncode < 0x7FFFFFFF:
+                    self._logger.info(
+                        f"Process pid {self._process.pid} exited with code: {self._returncode} (unsigned) / {hex(self._returncode)} (hex)"
+                    )
+                else:
+
+                    def _tosigned(n: int) -> int:
+                        b = (n & 0xFFFFFFFF).to_bytes(4, "big", signed=False)
+                        return int.from_bytes(b, "big", signed=True)
+
+                    self._logger.info(
+                        f"Process pid {self._process.pid} exited with code: {self._returncode} (unsigned) / {hex(self._returncode)} (hex) / {_tosigned(self._returncode)} (signed)"
+                    )
 
             if self._callback:
                 self._callback()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The current code does not log the process exit code when a subprocess exits. 

### What was the solution? (How)

We print the return code as both decimal and hexidecimal, and further include the negative decimal value if the exit code would be negative as a signed 32-bit integer.

### What is the impact of this change?

Session logs contain additional diagnostic information that may be helpful when tracking down errors.

### How was this change tested?

Yes, indirectly by the unit tests when run in the CI on posix & windows. Also manually by copy/paste into an interactive Python session.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*