### PR TITLE
fix: upper case all env vars on Windows

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -110,9 +110,26 @@ both of these environments.
 To run the impersonation tests you will require a separate user on your workstation, and its
 password, that you are able to logon as. Then:
 
+1. Run the tests on the Windows Command Line;
+   * The tests have mixed results when running in the VSCode terminal.
+1. Run the tests with the system install of Python.
+   * Using a virtual environment can cause permission issues.
+1. The second user needs read, list, and execute permissions on the source code directory and hatch directory.
+   * Make sure object inheritence permissions are turned on.
+1. The user running the tests is an Administrator, LocalSystem, or LocalService user as your
+   security posture requires;
+1. The user running the tests has the [Replace a process level token](https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/replace-a-process-level-token)
+   privilege.
+   1. In the Windows search bar, search for `Local Security Policy`;
+   1. Navigate to `Local Policies` -> `User Rights Assignment`;
+   1. Scroll down to the `Replace a process level token` policy;
+   1. Double click the `Replace a process level token` policy;
+   1. Click `Add User or Group...`;
+   1. Add the user that will be running the test;
+   1. Click ok on both dialogs.
 1. Set the environment variable `OPENJD_TEST_WIN_USER_NAME` to the username of that user;
-2. Set the environment variable `OPENJD_TEST_WIN_USER_PASSWORD` to that user's password; and
-3. Then run the tests with `hatch run test` as normal.
+1. Set the environment variable `OPENJD_TEST_WIN_USER_PASSWORD` to that user's password; and
+1. Then run the tests with `hatch run test` as normal.
     * If done correctly, then you should not see any xfail tests related to impersonation.
 
 Run these tests in both:

--- a/src/openjd/sessions/_win32/_popen_as_user.py
+++ b/src/openjd/sessions/_win32/_popen_as_user.py
@@ -149,7 +149,12 @@ class PopenWindowsAsUser(Popen):
             user_env: ctypes.c_void_p, env: dict[str, Optional[str]]
         ) -> ctypes.c_wchar_p:
             user_env_dict = cast(dict[str, Optional[str]], environment_block_to_dict(user_env))
-            user_env_dict.update(**env)
+            # All environment keys are converted to uppercase. This is because while Windows environment variables are case insensitive, the win32 api
+            # allows you to store multiple keys of mixed case, for example the win32 api would allow you
+            # to set both "PATH" and "Path" as environment variable keys. This leads to undefined behaviour when calling one of the keys.
+            user_env_dict = {k.upper(): v for k, v in user_env_dict.items()}
+            upper_cased_env = {k.upper(): v for k, v in env.items()}
+            user_env_dict.update(**upper_cased_env)
             result = {k: v for k, v in user_env_dict.items() if v is not None}
             return environment_block_from_dict(result)
 


### PR DESCRIPTION
Fixes: https://github.com/OpenJobDescription/openjd-sessions-for-python/issues/157

### What was the problem/requirement? (What/Why)
We've observed on Windows systems that even though environment variables are case insensitive, the win32 API will allow duplicate environment variables with different casing. This causes issues as openjd reads in user environment variables via Python, which uppercases all environment variables it reads in on Windows. If there already existed an environment variable in the system that wasn't uppercased, say Path, and openjd reads in a variable it needs to update, say PATH. The win32 API will accept both. This leads to undefined behaviour when Windows accesses that environment variable

### What was the solution? (How)
Upper case all environment variables that come into openjd on Windows, whether it's through the win32 API or openjd.

### What is the impact of this change?
Paths added by printing `openjd_env: key=value` should override environment variables as expected, regardless of casing.

### How was this change tested?
I've added unit tests that ensure that the environment variables are all converted to upper case as expected and that variables are overwritten as expected regardless of casing.

### Was this change documented?
N/A, but I've also added some dev documentation to make running the impersonation tests on Windows easier.

### Is this a breaking change?
N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*