### PR TITLE
test: fix test where ping is not available

### DIFF
--- a/test/openjd/sessions/test_subprocess.py
+++ b/test/openjd/sessions/test_subprocess.py
@@ -437,7 +437,7 @@ sys.exit(0)
                 (10, [0, 1, 2, 3]),
             ]
             for command in [
-                f'["ping", "localhost", "{"-n" if os.name == "nt" else "-c"}", "{s}"]',
+                f'["python", "-c", "import time; [print(\\"Hello World {{i}}\\") for i in range({s}) if not time.sleep(1)]"]',
                 f'["python", "-c", "import time; time.sleep({s})"]',
             ]
         ],


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

- In environments where `ping` is not available, the test `test_run_gracetime_when_process_ends_but_grandchild_uses_stdout` was failing

### What was the solution? (How)

Use python instead.

### What is the impact of this change?

The test `test_run_gracetime_when_process_ends_but_grandchild_uses_stdout` succeeds in environments where `ping` is not available

### How was this change tested?

Ran tests locally

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*