### PR TITLE
feat: introduce log content on log records

### DIFF
--- a/src/openjd/sessions/__init__.py
+++ b/src/openjd/sessions/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from ._logging import LOG
+from ._logging import LOG, LogContent
 from ._path_mapping import PathFormat, PathMappingRule
 from ._session import ActionStatus, Session, SessionCallbackType, SessionState
 from ._session_user import (
@@ -25,6 +25,7 @@ __all__ = (
     "EnvironmentModel",
     "EnvironmentScriptModel",
     "LOG",
+    "LogContent",
     "PathFormat",
     "PathMappingRule",
     "PosixSessionUser",

--- a/src/openjd/sessions/_embedded_files.py
+++ b/src/openjd/sessions/_embedded_files.py
@@ -5,7 +5,6 @@ import stat
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
-from logging import LoggerAdapter
 from pathlib import Path
 from shutil import chown
 from tempfile import mkstemp
@@ -16,6 +15,7 @@ from openjd.model.v2023_09 import EmbeddedFileText as EmbeddedFileText_2023_09
 from openjd.model.v2023_09 import (
     ValueReferenceConstants as ValueReferenceConstants_2023_09,
 )
+from ._logging import LoggerAdapter
 from ._session_user import PosixSessionUser, SessionUser, WindowsSessionUser
 from ._types import EmbeddedFilesListType, EmbeddedFileType
 

--- a/src/openjd/sessions/_logging.py
+++ b/src/openjd/sessions/_logging.py
@@ -1,22 +1,89 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
 
+from typing import Any, MutableMapping, TypedDict
+from enum import Flag, auto
 import logging
 
-__all__ = "LOG"
+__all__ = ["LOG", "LoggerAdapter", "LogExtraInfo", "LogContent"]
+
+
+class LogContent(Flag):
+    """
+    A Flag Enum which describes the content of a log record.
+    """
+
+    BANNER = auto()  # Logs which contain a banner, such as to visually seperate log sections
+    FILE_PATH = auto()  # Logs which contain a filepath
+    FILE_CONTENTS = auto()  # Logs which contain the contents of a file
+    COMMAND_OUTPUT = auto()  # Logs which contain the output of a command run
+    EXCEPTION_INFO = (
+        auto()
+    )  # Logs which contain an exception openjd encountered, potentially including sensitive information such as filepaths or host information.
+    PROCESS_CONTROL = (
+        auto()
+    )  # Logs which contain information related to starting, killing, or signalling processes.
+    PARAMETER_INFO = (
+        auto()
+    )  # Logs which contain details about parameters and their values pertaining to the running action
+    HOST_INFO = (
+        auto()
+    )  # Logs which contain details about the system environment, e.g. dependency versions, OS name, CPU architecture.
+
+
+class LogExtraInfo(TypedDict):
+    """
+    A TypedDict which contains extra information to be added to the "extra" key of a log record.
+    """
+
+    openjd_log_content: LogContent | None
+
+
+class LoggerAdapter(logging.LoggerAdapter):
+    """
+    LoggerAdapter which merges the "extra" kwarg instead of replacing with what the LoggerAdapter was initialized with.
+    """
+
+    def process(
+        self, msg: Any, kwargs: MutableMapping[str, Any]
+    ) -> tuple[Any, MutableMapping[str, Any]]:
+        """
+        Typically the LoggerAdaptor simply replaces the `extra` key in the kwargs with the one initialized with the
+        adapter. However, we want to merge the two dictionaries, so we override it here.
+        """
+        if "extra" not in kwargs:
+            kwargs["extra"] = self.extra
+        else:
+            kwargs["extra"] |= self.extra
+        return msg, kwargs
+
 
 # Name the logger for the sessions module, rather than this specific file
 LOG = logging.getLogger(".".join(__name__.split(".")[:-1]))
+"""
+The logger of the openjd sessions module. The logger has the name openjd.sessions and is used 
+throughout the openjd sessions module to provide information on actions the module is taking, as
+well as any output from commands run during Sessions.
+
+Some LogRecords sent to the logger will have an extra attribute named "openjd_log_content" who's 
+value is a LogContent which provides information on what data is contained in the LogRecord, or None
+if there is no applicable LogContent field (for example, a message like "Ending Session")
+
+If the LogRecord does not have the "openjd_log_content" no guarantees are made as to what content
+is in the LogRecord. LogRecords that contain LogContent.EXECPTION_INFO may also transitively include
+potentially sensitive information like filepaths or host info due to the nature of exception messages.
+"""
 LOG.setLevel(logging.INFO)
 
 
-def log_section_banner(logger: logging.LoggerAdapter, section_title: str) -> None:
+def log_section_banner(logger: LoggerAdapter, section_title: str) -> None:
     logger.info("")
     logger.info("==============================================")
     logger.info(f"--------- {section_title}")
     logger.info("==============================================")
 
 
-def log_subsection_banner(logger: logging.LoggerAdapter, section_title: str) -> None:
+def log_subsection_banner(logger: LoggerAdapter, section_title: str) -> None:
     logger.info("----------------------------------------------")
     logger.info(section_title)
     logger.info("----------------------------------------------")

--- a/src/openjd/sessions/_runner_base.py
+++ b/src/openjd/sessions/_runner_base.py
@@ -9,7 +9,6 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
-from logging import LoggerAdapter
 from pathlib import Path
 from threading import Lock, Timer
 from typing import Callable, Optional, Sequence, Type, cast
@@ -20,7 +19,7 @@ from openjd.model import SymbolTable
 from openjd.model import FormatStringError
 from openjd.model.v2023_09 import Action as Action_2023_09
 from ._embedded_files import EmbeddedFiles, EmbeddedFilesScope, write_file_for_user
-from ._logging import log_subsection_banner
+from ._logging import log_subsection_banner, LoggerAdapter
 from ._os_checker import is_posix
 from ._session_user import SessionUser
 from ._subprocess import LoggingSubprocess

--- a/src/openjd/sessions/_runner_env_script.py
+++ b/src/openjd/sessions/_runner_env_script.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from datetime import timedelta
-from logging import LoggerAdapter
+from ._logging import LoggerAdapter
 from pathlib import Path
 from typing import Callable, Optional
 

--- a/src/openjd/sessions/_runner_step_script.py
+++ b/src/openjd/sessions/_runner_step_script.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from datetime import timedelta
-from logging import LoggerAdapter
+from ._logging import LoggerAdapter
 from pathlib import Path
 from typing import Callable, Optional
 

--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -8,7 +8,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from logging import Filter, LoggerAdapter
+from logging import Filter
 from os import name as os_name
 from os import stat as os_stat
 from pathlib import Path
@@ -30,7 +30,7 @@ from openjd.model.v2023_09 import (
 )
 from ._action_filter import ActionMessageKind, ActionMonitoringFilter
 from ._embedded_files import write_file_for_user
-from ._logging import LOG, log_section_banner
+from ._logging import LOG, log_section_banner, LoggerAdapter
 from ._os_checker import is_posix, is_windows
 from ._path_mapping import PathMappingRule
 from ._runner_base import ScriptRunnerBase

--- a/src/openjd/sessions/_subprocess.py
+++ b/src/openjd/sessions/_subprocess.py
@@ -12,7 +12,7 @@ if is_windows():
 from queue import Queue, Empty
 from typing import Any
 from threading import Event, Thread
-from logging import LoggerAdapter
+from ._logging import LoggerAdapter
 from subprocess import DEVNULL, PIPE, STDOUT, Popen, list2cmdline, run
 from typing import Callable, Optional, Sequence, cast
 from pathlib import Path

--- a/src/openjd/sessions/_tempdir.py
+++ b/src/openjd/sessions/_tempdir.py
@@ -2,7 +2,7 @@
 
 import os
 import stat
-from logging import LoggerAdapter
+from ._logging import LoggerAdapter
 from pathlib import Path
 from shutil import chown, rmtree
 from tempfile import gettempdir, mkdtemp

--- a/src/openjd/sessions/_win32/_locate_executable.py
+++ b/src/openjd/sessions/_win32/_locate_executable.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import shutil
-from logging import INFO, LoggerAdapter, getLogger
+from logging import INFO, getLogger
 from logging.handlers import QueueHandler
 from pathlib import Path
 from queue import Empty, SimpleQueue
@@ -12,6 +12,7 @@ from typing import Optional, Sequence
 
 from .._session_user import SessionUser
 from .._subprocess import LoggingSubprocess
+from .._logging import LoggerAdapter
 
 _internal_logger_lock = Lock()
 _internal_logger = getLogger("openjd_sessions_runner_base_internal_logger")

--- a/test/openjd/sessions/conftest.py
+++ b/test/openjd/sessions/conftest.py
@@ -3,7 +3,7 @@
 import os
 import random
 import string
-from logging import INFO, LoggerAdapter, getLogger
+from logging import INFO, getLogger
 from logging.handlers import QueueHandler
 from queue import Empty, SimpleQueue
 from typing import Generator
@@ -11,6 +11,7 @@ import pytest
 
 from openjd.sessions import PosixSessionUser, WindowsSessionUser, BadCredentialsException
 from openjd.sessions._os_checker import is_posix, is_windows
+from openjd.sessions._logging import LoggerAdapter
 
 if is_windows():
     from openjd.sessions._win32._helpers import (  # type: ignore

--- a/test/openjd/sessions/test_action_filter.py
+++ b/test/openjd/sessions/test_action_filter.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from hashlib import sha256
-from logging import LoggerAdapter
+from openjd.sessions._logging import LoggerAdapter
 from logging.handlers import QueueHandler
 from queue import SimpleQueue
 from typing import Union


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Consumers of the `openjd_sessions` module may want a means of filtering logs based on their contents. 

### What was the solution? (How)

In order to solve this problem, this commit introduces a structure we can add to the `extra` kwarg when logging messages. The value provided to the `extra` kwarg must be of type `dict[str, Any]`, with the limitation that the keys cannot be an [existing attribute name in LogRecord](https://docs.python.org/3/library/logging.html#logrecord-attributes).

This commit then introduces a  `LogExtraInfo`  class which is a Dictionary containing one key: `openjd_log_content`.

`openjd_log_content` is a `Flag` which allows combining multiple `LogContent` values through bitwise operators in order to indicate which contents are in the logged message. 

### What is the impact of this change?

A `LogContent` flag becomes available to attached to logged messages, that consumers of this package can use to filter log messages based on the type of log message.

### How was this change tested?

> Have you run the unit tests?

Yes, also added unit tests to confirm all expected fields in log records still exist

### Was this change documented?

It is through the changelog. 
  
### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*