### PR TITLE
fix: Notify should use the non-service python.

### DIFF
--- a/src/openjd/sessions/_subprocess.py
+++ b/src/openjd/sessions/_subprocess.py
@@ -467,7 +467,8 @@ class LoggingSubprocess(object):
 
         # _process will be running in new console, we run another process to attach to it and send signal
         cmd = [
-            sys.executable,
+            # When running in a service context, we want to call the non-service Python binary
+            sys.executable.lower().replace("pythonservice.exe", "python.exe"),
             str(WINDOWS_SIGNAL_SUBPROC_SCRIPT_PATH),
             str(self._process.pid),
         ]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Notifying the windows subprocess of the CTRL_BREAK_EVENT will use the service python if running in the context of a service. It should be using the system python.

### What was the solution? (How)

Replace the `"pythonservice.exe"` path with `"python.exe"`

### What is the impact of this change?

Allow the `CTRL_BREAK_EVENT` to be sent to the subprocess correctly, allowing it to gracefully shutdown.

### How was this change tested?

Ran unit tests.

### Was this change documented?

Just a small comment.

### Is this a breaking change?

No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*