### PR TITLE
test: upgrade docker testing compatibility to Docker 25.x

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,8 @@ To develop the Python code in this repository you will need:
 
 1. Python 3.9 or higher. We recommend [mise](https://github.com/jdx/mise) if you would like to run more than one version
    of Python on the same system. When running unit tests against all supported Python versions, for instance.
-2. The [hatch](https://github.com/pypa/hatch) package installed (`pip install --upgrade hatch`) into your Python environment. 
+2. The [hatch](https://github.com/pypa/hatch) package installed (`pip install --upgrade hatch`) into your Python environment.
+3. If working on Linux cross-user support, Docker version 23.x or newer
 
 You can develop on a Linux, MacOs, or Windows workstation, but you will find that some of the support scripting is specific to
 Linux workstations.
@@ -151,18 +152,18 @@ on how to run these tests.
 
 #### User Impersonation: POSIX-Based Systems
 
-To run the impersonation tests you must create additional users and groups for the impersonation
-tests on your local system and then set environment variables before running the tests.
-
-Scripting has been added to this repository to test this functionality on Linux using
-docker containers that we have set up for this purpose.
+The codebase contains cross-user impersonation tests that rely on the existence of specific users and
+groups. There are scripts in the repository that automate the creation of Docker container images
+with the required user/group setup and then running the tests within a container that uses the
+image.
 
 To run these tests:
 1. With users configured locally in /etc/passwd & /etc/groups: `scripts/run_sudo_tests.sh --build`
 2. With users via an LDAP client: `scripts/run_sudo_tests.sh --build --ldap`
 
-If you are unable to use the provided docker container then you need to set up the `OPENJD_TEST_SUDO_*`
-environment variables and their referenced users and groups as in the Dockerfile under
+If you are unable to use the provided docker container setup, then you will first need to create
+the required users and groups on your development machine, and populate the `OPENJD_TEST_SUDO_*`
+environment variables as done in the Dockerfile under
 `testing_containers/localuser_sudo_environment/Dockerfile` in this repository.
 
 #### User Impersonation: Windows-Based Systems

--- a/scripts/run_sudo_tests.sh
+++ b/scripts/run_sudo_tests.sh
@@ -46,21 +46,22 @@ if test "${PIP_INDEX_URL:-}" != ""; then
     # If PIP_INDEX_URL is set, then export that in to the container
     # so that `pip install` run in the container will fetch packages
     # from the correct repository.
-    ARGS="${ARGS} -e  PIP_INDEX_URL=${PIP_INDEX_URL}"
+    ARGS="${ARGS} -e PIP_INDEX_URL=${PIP_INDEX_URL}"
 fi
 
 if test "${USE_LDAP}" == "True"; then
-    ARGS="${ARGS} -h ldap.environment.internal"
+    CONTAINER_HOSTNAME=ldap.environment.internal
     CONTAINER_IMAGE_TAG="openjd_ldap_test"
     CONTAINER_IMAGE_DIR="ldap_sudo_environment"
 else
-    ARGS="${ARGS} -h localuser.environment.internal"
+    CONTAINER_HOSTNAME=localuser.environment.internal
     CONTAINER_IMAGE_TAG="openjd_localuser_test"
     CONTAINER_IMAGE_DIR="localuser_sudo_environment"
 fi
+ARGS="${ARGS} -h ${CONTAINER_HOSTNAME}"
 
 if test "${DO_BUILD}" == "True"; then
-    docker build testing_containers/"${CONTAINER_IMAGE_DIR}" -t "${CONTAINER_IMAGE_TAG}"
+    docker build -t "${CONTAINER_IMAGE_TAG}" --build-arg "BUILDKIT_SANDBOX_HOSTNAME=${CONTAINER_HOSTNAME}" "testing_containers/${CONTAINER_IMAGE_DIR}"
 fi
 
 if test "${BUILD_ONLY}" == "True"; then

--- a/testing_containers/ldap_sudo_environment/Dockerfile
+++ b/testing_containers/ldap_sudo_environment/Dockerfile
@@ -29,8 +29,7 @@ WORKDIR /code
 #   hostuser: hostuser, sharedgroup
 #   targetuser: targetuser, sharedgroup
 #   disjointuser: disjointuser, disjointgroup
-RUN echo $(grep $(hostname) /etc/hosts | cut -f1) ldap.environment.internal >> /etc/hosts && \
-    apt-get update && export DEBIAN_FRONTEND=noninteractive && \
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y vim screen slapd ldap-utils && \
     echo slapd   slapd/password1 password | debconf-set-selections -v && \
     echo slapd   slapd/password2 password | debconf-set-selections -v && \

--- a/testing_containers/ldap_sudo_environment/README.md
+++ b/testing_containers/ldap_sudo_environment/README.md
@@ -1,19 +1,22 @@
 
 ## Build
 ```
-docker build testing_containers/ldap_sudo_environment -t openjd_ldap_test
+docker build --build-arg BUILDKIT_SANDBOX_HOSTNAME=ldap.environment.internal -t openjd_ldap_test testing_containers/ldap_sudo_environment
 ```
 
 ## Run Interactive Bash
 To start an interactive bash session:
 ```
-docker run -h ldap.environment.internal --rm -v $(pwd):/code:ro -e PIP_INDEX_URL=${PIP_INDEX_URL} -it --entrypoint bash openjd_ldap_test:latest
+docker run -h ldap.environment.internal --rm -it  openjd_ldap_test:latest bash
 ```
 To start the LDAP Server and Client:
+
 ```
-service slapd start && service nscd restart && service nslcd restart
+/config/start_ldap.sh
 ```
+
 Login via ldap:
+
 ```
 login -p hostuser
 ```


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1.  The development documentation (`DEVELOPMENT.md`) for using the docker container test workflow for POSIX user impersonation tests was not clear/accurate
2.  The scripting for using the docker container tests was not compatible with modern Docker. Attempting to build the LDAP docker image with Docker 25.x failed because it could not write to `/etc/hosts` which is mounted as read-only.

### What was the solution? (How)

1.  Fixed up the documentation to clarify that developers should first attempt using the docker container test workflow. If that is not possible (e.g. unable to use Docker), then developers should inspect the Dockerfiles and replicate the setup on their development machine
2. Switched to using the `BUILDKIT_SANDBOX_HOSTNAME` ([ref docs](https://docs.docker.com/reference/dockerfile/#buildkit-built-in-build-args)) to specify the container hostname at build-time. [Buildkit](https://docs.docker.com/build/buildkit/) is the new default container image build backend for Docker version 23.0 and newer.

### What is the impact of this change?

Developers able to use more modern versions of Docker (&ge; 23.0)

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Ran the Linux automated tests using the documented Docker workflow and they passed

### Was this change documented?

The relevant developer documentation was updated:
- `DEVELOPMENT.md`
- `testing_containers/ldap_sudo_environment/README.md`

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*