### PR TITLE
fix: Run Windows Session cleanup at high priority.

### DIFF
--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -437,6 +437,11 @@ class Session(object):
                         recursive_delete_cmd = ["rm", "-rf"]
                     else:
                         recursive_delete_cmd = [
+                            "start",
+                            '"Powershell"',
+                            "/high",
+                            "/wait",
+                            "/b",
                             "powershell",
                             "-Command",
                             "Remove-Item",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

During session cleanup, the powershell Remove-Item command can get starved for cycles if there's another process consuming too much of the CPU. 

### What was the solution? (How)

Have the cleanup command run at a higher priority. 

### What is the impact of this change?

An important task, like session clean up, should be prioritized. This allows clean up to happen when it otherwise might not. 

### How was this change tested?

This change was tested in the context of a Deadline Cloud Worker Agent. My CMF was running a CPU heavy workload. I observed in the session logs that clean up completed quickly during a cancelation. Prior to my change, a cancelation was taking > 5 min. 

### Was this change documented?

No

### Is this a breaking change?

No.

### Does this change impact security?

No.
----
