### PR TITLE
feat: add log content metadata to log records

### DIFF
--- a/hatch_version_hook.py
+++ b/hatch_version_hook.py
@@ -102,7 +102,7 @@ class CustomBuildHook(BuildHookInterface):
             opt for opt in self.REQUIRED_OPTS if opt not in self.config or not self.config[opt]
         ]
         if missing_required_opts:
-            _logger.warn(
+            _logger.warning(
                 f"Required options {missing_required_opts} are missing or empty. "
                 "Contining without copying sources to destinations...",
                 file=sys.stderr,

--- a/src/openjd/sessions/_action_filter.py
+++ b/src/openjd/sessions/_action_filter.py
@@ -8,7 +8,7 @@ import re
 from enum import Enum
 from typing import Any, Callable
 
-from ._logging import LOG
+from ._logging import LOG, LogContent, LogExtraInfo
 
 __all__ = ("ActionMessageKind", "ActionMonitoringFilter")
 
@@ -155,14 +155,18 @@ class ActionMonitoringFilter(logging.Filter):
                 # The only way that this happens is if filter_matcher is constructed incorrectly.
                 all_matched_groups = ",".join(k for k in matched_named_groups)
                 LOG.error(
-                    f"Open Job Description: Malformed output stream filter matched multiple kinds ({all_matched_groups})"
+                    f"Open Job Description: Malformed output stream filter matched multiple kinds ({all_matched_groups})",
+                    extra=LogExtraInfo(openjd_log_content=LogContent.COMMAND_OUTPUT),
                 )
                 return True
             message_kind = ActionMessageKind(matched_named_groups[0])
             try:
                 handler = self._internal_handlers[message_kind]
             except KeyError:
-                LOG.error(f"Open Job Description: Unhandled message kind ({message_kind.value})")
+                LOG.error(
+                    f"Open Job Description: Unhandled message kind ({message_kind.value})",
+                    extra=LogExtraInfo(openjd_log_content=LogContent.COMMAND_OUTPUT),
+                )
                 return True
             try:
                 handler(message)

--- a/src/openjd/sessions/_embedded_files.py
+++ b/src/openjd/sessions/_embedded_files.py
@@ -15,7 +15,7 @@ from openjd.model.v2023_09 import EmbeddedFileText as EmbeddedFileText_2023_09
 from openjd.model.v2023_09 import (
     ValueReferenceConstants as ValueReferenceConstants_2023_09,
 )
-from ._logging import LoggerAdapter
+from ._logging import LoggerAdapter, LogExtraInfo, LogContent
 from ._session_user import PosixSessionUser, SessionUser, WindowsSessionUser
 from ._types import EmbeddedFilesListType, EmbeddedFileType
 
@@ -148,7 +148,12 @@ class EmbeddedFiles:
             # Add symbols to the symbol table
             for record in records:
                 symtab[record.symbol] = str(record.filename)
-                self._logger.info(f"Mapping: {record.symbol} -> {record.filename}")
+                self._logger.info(
+                    f"Mapping: {record.symbol} -> {record.filename}",
+                    extra=LogExtraInfo(
+                        openjd_log_content=LogContent.FILE_PATH | LogContent.PARAMETER_INFO
+                    ),
+                )
 
             # Write the files to disk.
             for record in records:
@@ -225,5 +230,10 @@ class EmbeddedFiles:
         # Create the file as r/w owner, and optionally group
         write_file_for_user(filename, data, self._user, additional_permissions=execute_permissions)
 
-        self._logger.info(f"Wrote: {file.name} -> {str(filename)}")
-        self._logger.debug("Contents:\n%s", data)
+        self._logger.info(
+            f"Wrote: {file.name} -> {str(filename)}",
+            extra=LogExtraInfo(openjd_log_content=LogContent.FILE_PATH),
+        )
+        self._logger.debug(
+            "Contents:\n%s", data, extra=LogExtraInfo(openjd_log_content=LogContent.FILE_CONTENTS)
+        )

--- a/src/openjd/sessions/_logging.py
+++ b/src/openjd/sessions/_logging.py
@@ -75,15 +75,17 @@ potentially sensitive information like filepaths or host info due to the nature 
 """
 LOG.setLevel(logging.INFO)
 
+_banner_log_extra = LogExtraInfo(openjd_log_content=LogContent.BANNER)
+
 
 def log_section_banner(logger: LoggerAdapter, section_title: str) -> None:
     logger.info("")
-    logger.info("==============================================")
-    logger.info(f"--------- {section_title}")
-    logger.info("==============================================")
+    logger.info("==============================================", extra=_banner_log_extra)
+    logger.info(f"--------- {section_title}", extra=_banner_log_extra)
+    logger.info("==============================================", extra=_banner_log_extra)
 
 
 def log_subsection_banner(logger: LoggerAdapter, section_title: str) -> None:
-    logger.info("----------------------------------------------")
-    logger.info(section_title)
-    logger.info("----------------------------------------------")
+    logger.info("----------------------------------------------", extra=_banner_log_extra)
+    logger.info(section_title, extra=_banner_log_extra)
+    logger.info("----------------------------------------------", extra=_banner_log_extra)

--- a/src/openjd/sessions/_tempdir.py
+++ b/src/openjd/sessions/_tempdir.py
@@ -2,7 +2,7 @@
 
 import os
 import stat
-from ._logging import LoggerAdapter
+from ._logging import LoggerAdapter, LogContent, LogExtraInfo
 from pathlib import Path
 from shutil import chown, rmtree
 from tempfile import gettempdir, mkdtemp
@@ -37,7 +37,8 @@ def custom_gettempdir(logger: Optional[LoggerAdapter] = None) -> str:
             program_data_path = r"C:\ProgramData"
             if logger:
                 logger.warning(
-                    f'"PROGRAMDATA" is not set. Set the root directory to the {program_data_path}'
+                    f'"PROGRAMDATA" is not set. Set the root directory to the {program_data_path}',
+                    extra=LogExtraInfo(openjd_log_content=LogContent.FILE_PATH),
                 )
 
         temp_dir_parent = os.path.join(program_data_path, "Amazon")

--- a/src/openjd/sessions/_tempdir.py
+++ b/src/openjd/sessions/_tempdir.py
@@ -37,7 +37,7 @@ def custom_gettempdir(logger: Optional[LoggerAdapter] = None) -> str:
             program_data_path = r"C:\ProgramData"
             if logger:
                 logger.warning(
-                    f'"PROGRAMDATA" is not set. Set the root directory to the {program_data_path}',
+                    f'Environment variable "PROGRAMDATA" is not set. Creating the session working directories under {program_data_path}',
                     extra=LogExtraInfo(openjd_log_content=LogContent.FILE_PATH),
                 )
 

--- a/test/openjd/sessions/test_session.py
+++ b/test/openjd/sessions/test_session.py
@@ -490,7 +490,7 @@ class TestSessionInitialization:
                                 lambda rec: rec.msg.startswith(expected_err_prefix), caplog.records
                             )
                         )[0]
-                        assert error_record.levelno == logging.WARN
+                        assert error_record.levelno == logging.WARNING
 
     @pytest.mark.usefixtures("caplog")  # built-in fixture
     def test_posix_permissions_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

https://github.com/OpenJobDescription/openjd-sessions-for-python/pull/170 added the ability to add a `LogContent` flag to the `extra` field of logging statements. 

With that merged, we need to now label each logging statement with the appropriate `LogContent` Flags.

### What was the solution? (How)

Look through all instances of `.debug`, `.info`, `.warn` (deprecated and changed to `.warning` where applicable), `.warning`, `.error`, `.exception`, `.critical`, and `.log`, and apply the relevant flags.

### What is the impact of this change?

A `LogContent` flag becomes available to logged messages, that consumers of this package can use to filter log messages based on the type of log message.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?

Yes

### Was this change documented?

Yes in https://github.com/OpenJobDescription/openjd-sessions-for-python/pull/170

### Is this a breaking change?

No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*