### PR TITLE
feat: add ability to not log banner when running a task

### DIFF
--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -760,6 +760,7 @@ class Session(object):
         step_script: StepScriptModel,
         task_parameter_values: TaskParameterSet,
         os_env_vars: Optional[dict[str, str]] = None,
+        log_task_banner: bool = True,
     ) -> None:
         """Run a Task within the Session.
         This method is non-blocking; it will exit when the subprocess is either confirmed to have
@@ -776,11 +777,15 @@ class Session(object):
                 by values defined in Environments.
                     Key: Environment variable name
                     Value: Value for the environment variable.
+            log_task_banner (bool): Whether to log a banner before running the Task.
+                Default: True
         """
         if self.state != SessionState.READY:
             raise RuntimeError("Session must be in the READY state to run a task.")
 
-        log_section_banner(self._logger, "Running Task")
+        if log_task_banner:
+            log_section_banner(self._logger, "Running Task")
+
         if task_parameter_values:
             self._logger.info(
                 "Parameter values:",

--- a/test/openjd/sessions/test_session.py
+++ b/test/openjd/sessions/test_session.py
@@ -698,6 +698,26 @@ class TestSessionRunTask_2023_09:  # noqa: N801
             assert session.action_status == ActionStatus(state=ActionState.SUCCESS, exit_code=0)
             assert "Jvalue Jvalue" in caplog.messages
             assert "Pvalue Pvalue" in caplog.messages
+            assert "--------- Running Task" in caplog.messages
+
+    def test_run_task_no_log_banners(
+        self, caplog: pytest.LogCaptureFixture, fix_basic_task_script: StepScript_2023_09
+    ) -> None:
+        # GIVEN
+        # This ensures that the log_task_banner argument is correctly controlling the task banner logging.
+        session_id = uuid.uuid4().hex
+        job_params = {"J": ParameterValue(type=ParameterValueType.STRING, value="Jvalue")}
+        task_params = {"P": ParameterValue(type=ParameterValueType.STRING, value="Pvalue")}
+        with Session(session_id=session_id, job_parameter_values=job_params) as session:
+            # WHEN
+            session.run_task(
+                step_script=fix_basic_task_script,
+                task_parameter_values=task_params,
+                log_task_banner=False,
+            )
+
+            # THEN
+            assert "--------- Running Task" not in caplog.messages
 
     def test_run_task_with_env_vars(self, caplog: pytest.LogCaptureFixture) -> None:
         # GIVEN


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Consumers of the `openjd_sessions` module may want to control the task log banners by turning it off. Additionally, they can use [_logging.py](https://github.com/OpenJobDescription/openjd-sessions-for-python/blob/mainline/src/openjd/sessions/_logging.py) to pass log the banner of their choice.

### What was the solution? (How)
Add an argument `log_task_banner` to `run_task` to optionally turn off the banner logging. By default, the task banner logging is set to `True`.

### What is the impact of this change?
Consumers of the `openjd_sessions` module  is able to turn off the banner logging for `run_task`.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? [Y]
- Build deadline-cloud consumer and submit jobs

```
2025-01-21 01:04:29,775 INFO Running Session Actions as user: 
2025-01-21 01:04:30,298 INFO ==============================================
2025-01-21 01:04:30,298 INFO --------- Job Attachments Download for Job
2025-01-21 01:04:30,298 INFO ==============================================
2025-01-21 01:04:30,424 INFO ----------------------------------------------
2025-01-21 01:04:30,424 INFO Phase: Setup
2025-01-21 01:04:30,424 INFO ----------------------------------------------
2025-01-21 01:04:30,424 INFO Writing embedded files for Task to disk.
2025-01-21 01:04:30,424 INFO Mapping: Task.File.AttachmentDownload -> /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/embedded_files3bcwd5o2/download.py
2025-01-21 01:04:30,424 INFO Wrote: AttachmentDownload -> /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/embedded_files3bcwd5o2/download.py
2025-01-21 01:04:30,425 INFO ----------------------------------------------
2025-01-21 01:04:30,425 INFO Phase: Running action
2025-01-21 01:04:30,425 INFO ----------------------------------------------
2025-01-21 01:04:30,426 INFO Running command /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmpmi2e6c22.sh
2025-01-21 01:04:30,427 INFO Command started as pid: 21671
2025-01-21 01:04:30,430 INFO Output:
2025-01-21 01:04:31,023 INFO 
2025-01-21 01:04:31,023 INFO Starting download...
2025-01-21 01:04:31,023 INFO Processed 3 files totaling 2.26 KB.
2025-01-21 01:04:31,023 INFO Skipped re-processing 0 files totaling 0.0 B.
2025-01-21 01:04:31,023 INFO Total processing time of 0.15163 seconds at 14.88 KB/s.
2025-01-21 01:04:31,023 INFO 
2025-01-21 01:04:31,023 INFO Finished downloading after 0.25078410375863314 seconds
2025-01-21 01:04:31,090 INFO Process pid 21671 exited with code: 0 (unsigned) / 0x0 (hex)
2025-01-21 01:04:31,131 INFO 
2025-01-21 01:04:31,131 INFO ==============================================
2025-01-21 01:04:31,131 INFO --------- Entering Environment: myenv
2025-01-21 01:04:31,131 INFO ==============================================
2025-01-21 01:04:31,131 INFO Setting: FOO=a-value
2025-01-21 01:04:31,132 INFO ----------------------------------------------
2025-01-21 01:04:31,132 INFO Phase: Setup
2025-01-21 01:04:31,132 INFO ----------------------------------------------
2025-01-21 01:04:31,132 INFO ----------------------------------------------
2025-01-21 01:04:31,132 INFO Phase: Running action
2025-01-21 01:04:31,132 INFO ----------------------------------------------
2025-01-21 01:04:31,132 INFO Running command /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmp_qtjt98m.sh
2025-01-21 01:04:31,133 INFO Command started as pid: 21693
2025-01-21 01:04:31,135 INFO Output:
2025-01-21 01:04:31,136 INFO env start
2025-01-21 01:04:31,136 INFO Process pid 21693 exited with code: 0 (unsigned) / 0x0 (hex)
2025-01-21 01:04:31,236 INFO 
2025-01-21 01:04:31,236 INFO ==============================================
2025-01-21 01:04:31,237 INFO --------- Running Task
2025-01-21 01:04:31,237 INFO ==============================================
2025-01-21 01:04:31,237 INFO ----------------------------------------------
2025-01-21 01:04:31,237 INFO Phase: Setup
2025-01-21 01:04:31,237 INFO ----------------------------------------------
2025-01-21 01:04:31,237 INFO Writing embedded files for Task to disk.
2025-01-21 01:04:31,237 INFO Mapping: Task.File.runScript -> /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/embedded_files3bcwd5o2/tmp6b38kfqv
2025-01-21 01:04:31,238 INFO Wrote: runScript -> /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/embedded_files3bcwd5o2/tmp6b38kfqv
2025-01-21 01:04:31,238 INFO ----------------------------------------------
2025-01-21 01:04:31,238 INFO Phase: Running action
2025-01-21 01:04:31,238 INFO ----------------------------------------------
2025-01-21 01:04:31,238 INFO Running command /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmpcrf1uh9q.sh
2025-01-21 01:04:31,239 INFO Command started as pid: 21696
2025-01-21 01:04:31,245 INFO Output:
2025-01-21 01:04:31,257 INFO Process pid 21696 exited with code: 0 (unsigned) / 0x0 (hex)
2025-01-21 01:04:31,342 INFO ==============================================
2025-01-21 01:04:31,342 INFO --------- Job Attachments Upload for Task
2025-01-21 01:04:31,342 INFO ==============================================
2025-01-21 01:04:31,343 INFO ----------------------------------------------
2025-01-21 01:04:31,343 INFO Phase: Setup
2025-01-21 01:04:31,343 INFO ----------------------------------------------
2025-01-21 01:04:31,343 INFO Writing embedded files for Task to disk.
2025-01-21 01:04:31,343 INFO Mapping: Task.File.AttachmentUpload -> /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/embedded_files3bcwd5o2/upload.py
2025-01-21 01:04:31,343 INFO Wrote: AttachmentUpload -> /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/embedded_files3bcwd5o2/upload.py
2025-01-21 01:04:31,344 INFO ----------------------------------------------
2025-01-21 01:04:31,344 INFO Phase: Running action
2025-01-21 01:04:31,344 INFO ----------------------------------------------
2025-01-21 01:04:31,344 INFO Running command /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmpp0s5blv9.sh
2025-01-21 01:04:31,345 INFO Command started as pid: 21713
2025-01-21 01:04:31,347 INFO Output:
2025-01-21 01:04:31,700 INFO Found difference at: computed_hashes.txt, Status: FileStatus.NEW
2025-01-21 01:04:31,795 INFO Hashing Attachments
2025-01-21 01:04:31,886 INFO Hashing Summary:
2025-01-21 01:04:31,887 INFO     Processed 1 file totaling 871.0 B.
2025-01-21 01:04:31,887 INFO     Skipped re-processing 0 files totaling 0.0 B.
2025-01-21 01:04:31,887 INFO     Total processing time of 0.01158 seconds at 75.19 KB/s.
2025-01-21 01:04:31,887 INFO 
2025-01-21 01:04:31,888 INFO Manifest generated at /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/diff/output-7bb58db7970d258345820e08f186f96d_job-46d45e5d7cf513932db440a435a142e2-2025-01-21T01-04-31.manifest
2025-01-21 01:04:32,262 INFO 
2025-01-21 01:04:32,262 INFO Starting upload...
2025-01-21 01:04:32,262 INFO Uploaded assets from /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/assetroot-c505a77d076c00137a3b, to s3:/XXX/job-3742c8ba9cac4dd0b37e1dc6066351f5/step-431e35e5d98c4721a26f119cc0d5bb2e/task-431e35e5d98c4721a26f119cc0d5bb2e-0/sessionaction-02335d30276b40eca1d8e09802548dc3-2/output-7bb58db7970d258345820e08f186f96d_job-46d45e5d7cf513932db440a435a142e2-2025-01-21T01-04-31.manifest, hashed data 86b760b4268410f25ac66b205b5b5ab0
2025-01-21 01:04:32,262 INFO Finished uploading after 0.5692453640513122 seconds
2025-01-21 01:04:32,373 INFO Process pid 21713 exited with code: 0 (unsigned) / 0x0 (hex)
2025-01-21 01:04:32,849 INFO 
2025-01-21 01:04:32,849 INFO ==============================================
2025-01-21 01:04:32,849 INFO --------- Exiting Environment: myenv
2025-01-21 01:04:32,849 INFO ==============================================
2025-01-21 01:04:32,849 INFO ----------------------------------------------
2025-01-21 01:04:32,849 INFO Phase: Setup
2025-01-21 01:04:32,850 INFO ----------------------------------------------
2025-01-21 01:04:32,850 INFO ----------------------------------------------
2025-01-21 01:04:32,850 INFO Phase: Running action
2025-01-21 01:04:32,850 INFO ----------------------------------------------
2025-01-21 01:04:32,850 INFO Running command /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmphcel3t8a.sh
2025-01-21 01:04:32,851 INFO Command started as pid: 21744
2025-01-21 01:04:32,854 INFO Output:
2025-01-21 01:04:32,855 INFO env end
2025-01-21 01:04:32,855 INFO Process pid 21744 exited with code: 0 (unsigned) / 0x0 (hex)
2025-01-21 01:04:33,029 INFO 
2025-01-21 01:04:33,029 INFO ==============================================
2025-01-21 01:04:33,029 INFO --------- Session Cleanup
2025-01-21 01:04:33,029 INFO ==============================================
2025-01-21 01:04:33,029 INFO Deleting working directory: /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll
2025-01-21 01:04:33,030 INFO Running command rm -rf /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmpmjefffv3.json /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmp_qtjt98m.sh /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmptmgznyku.json /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmpfo94uz36.json /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/diff /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/manifests /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmphcel3t8a.sh /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmpmi2e6c22.sh /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmppnuvux1n.json /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmpp0s5blv9.sh /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmpcrf1uh9q.sh /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/tmpzcb5ce_h.json /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/embedded_files3bcwd5o2 /sessions/session-02335d30276b40eca1d8e09802548dc3nbod6kll/assetroot-c505a77d076c00137a3b
2025-01-21 01:04:33,031 INFO Command started as pid: 21747
2025-01-21 01:04:33,033 INFO Output:
2025-01-21 01:04:33,034 INFO Process pid 21747 exited with code: 0 (unsigned) / 0x0 (hex)
```

### Was this change documented?

- Are relevant docstrings in the code base updated?
  - Yes

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*