### PR TITLE
fix!: use default timeout of 5 minutes for environment exits

### DIFF
--- a/src/openjd/sessions/_runner_base.py
+++ b/src/openjd/sessions/_runner_base.py
@@ -424,8 +424,24 @@ class ScriptRunnerBase(ABC):
             if self._callback is not None:
                 self._callback(ActionState.FAILED)
 
-    def _run_action(self, action: ActionModel, symtab: SymbolTable) -> None:
-        """Helper for derived classes to run a specific Action."""
+    def _run_action(
+        self,
+        action: ActionModel,
+        symtab: SymbolTable,
+        *,
+        default_timeout: Optional[timedelta] = None,
+    ) -> None:
+        """Helper for derived classes to run a specific Action.
+
+        Args:
+            action (ActionModel): The action model to be executed. Must be an
+                instance of Action_2023_09.
+            symtab (SymbolTable): Symbol table used for resolving command and
+                arguments.
+            default_timeout (Optional[timedelta], optional): Default timeout duration
+                for the action if no timeout is specified in the action. The default behaviour if
+                None is passed will allow the action to run indefinitely until it completes.
+        """
         assert isinstance(action, Action_2023_09)
         try:
             command = [action.command.resolve(symtab=symtab)]
@@ -444,7 +460,7 @@ class ScriptRunnerBase(ABC):
             if self._callback is not None:
                 self._callback(ActionState.FAILED)
         else:
-            time_limit: Optional[timedelta] = None
+            time_limit: Optional[timedelta] = default_timeout
             if action.timeout:
                 time_limit = timedelta(seconds=action.timeout)
             self._run(command, time_limit)

--- a/src/openjd/sessions/_runner_env_script.py
+++ b/src/openjd/sessions/_runner_env_script.py
@@ -27,6 +27,13 @@ from ._types import ActionModel, ActionState, EnvironmentScriptModel
 __all__ = ("EnvironmentScriptRunner",)
 
 
+_ENV_EXIT_DEFAULT_TIMEOUT = timedelta(minutes=5)
+"""The default timeout for environment exit actions if none is specified.
+
+See https://github.com/OpenJobDescription/openjd-specifications/wiki/2023-09-Template-Schemas#5-action
+"""
+
+
 class EnvironmentScriptRunner(ScriptRunnerBase):
     """Use this to run actions from an Environment."""
 
@@ -103,7 +110,12 @@ class EnvironmentScriptRunner(ScriptRunnerBase):
         ):
             raise NotImplementedError("Unknown model type")
 
-    def _run_env_action(self, action: ActionModel) -> None:
+    def _run_env_action(
+        self,
+        action: ActionModel,
+        *,
+        default_timeout: Optional[timedelta] = None,
+    ) -> None:
         """Run a specific given action from this Environment."""
 
         log_subsection_banner(self._logger, "Phase: Setup")
@@ -128,7 +140,7 @@ class EnvironmentScriptRunner(ScriptRunnerBase):
 
         # Construct the command by evalutating the format strings in the command
         self._action = action
-        self._run_action(self._action, symtab)
+        self._run_action(self._action, symtab, default_timeout=default_timeout)
 
     def enter(self) -> None:
         """Run the Environment's onEnter action."""
@@ -164,7 +176,10 @@ class EnvironmentScriptRunner(ScriptRunnerBase):
                 self._callback(ActionState.SUCCESS)
             return
 
-        self._run_env_action(self._environment_script.actions.onExit)
+        self._run_env_action(
+            self._environment_script.actions.onExit,
+            default_timeout=_ENV_EXIT_DEFAULT_TIMEOUT,
+        )
 
     def cancel(
         self, *, time_limit: Optional[timedelta] = None, mark_action_failed: bool = False

--- a/test/openjd/sessions/test_runner_base.py
+++ b/test/openjd/sessions/test_runner_base.py
@@ -641,6 +641,72 @@ class TestScriptRunnerBase:
         assert "Log from test 9" not in messages
 
     @pytest.mark.usefixtures("message_queue", "queue_handler")
+    @pytest.mark.parametrize(
+        argnames=("default_timeout_seconds", "action_timeout_seconds"),
+        argvalues=(
+            pytest.param(1, 5, id="action-timeout-prevails"),
+            pytest.param(2, None, id="default-applied"),
+            pytest.param(None, None, id="no-timeout"),
+        ),
+    )
+    def test_run_action_default_timeout(
+        self,
+        tmp_path: Path,
+        message_queue: SimpleQueue,
+        queue_handler: QueueHandler,
+        default_timeout_seconds: Optional[int],
+        action_timeout_seconds: Optional[int],
+    ) -> None:
+        # Tests that the effective timeout is applied correctly given a supplied default timeout
+        # and an optional timeout defined on the action
+
+        # GIVEN
+        expected_effective_timeout_seconds: Optional[int] = None
+        if action_timeout_seconds is not None:
+            expected_effective_timeout_seconds = action_timeout_seconds
+        elif default_timeout_seconds is not None:
+            expected_effective_timeout_seconds = default_timeout_seconds
+        default_timeout = (
+            timedelta(seconds=default_timeout_seconds)
+            if default_timeout_seconds is not None
+            else None
+        )
+        action = Action_2023_09(
+            command="{{Task.PythonInterpreter}}",
+            args=["{{Task.ScriptFile}}"],
+            timeout=action_timeout_seconds,
+        )
+        python_app_loc = (Path(__file__).parent / "support_files" / "app_20s_run.py").resolve()
+        symtab = SymbolTable(
+            source={
+                "Task.PythonInterpreter": sys.executable,
+                "Task.ScriptFile": str(python_app_loc),
+            }
+        )
+        logger = build_logger(queue_handler)
+        with TerminatingRunner(logger=logger, session_working_directory=tmp_path) as runner:
+            # WHEN
+            runner._run_action(action, symtab, default_timeout=default_timeout)
+            # wait for the process to exit
+            while runner.state == ScriptRunnerState.RUNNING:
+                time.sleep(0.2)
+
+        # THEN
+        if expected_effective_timeout_seconds is not None:
+            assert runner.state == ScriptRunnerState.TIMEOUT
+        else:
+            assert runner.state == ScriptRunnerState.SUCCESS
+        messages = collect_queue_messages(message_queue)
+        # The application prints out 0, ..., 19 once a second for 20s .
+        # If it ended early, then we printed the first but not the last.
+        print(messages)
+        if expected_effective_timeout_seconds is not None:
+            assert f"Log from test {expected_effective_timeout_seconds - 1}" in messages
+            assert f"Log from test {expected_effective_timeout_seconds + 1}" not in messages
+        else:
+            assert "Log from test 19" in messages
+
+    @pytest.mark.usefixtures("message_queue", "queue_handler")
     def test_run_action_bad_formatstring(
         self,
         tmp_path: Path,

--- a/test/openjd/sessions/test_runner_env_script.py
+++ b/test/openjd/sessions/test_runner_env_script.py
@@ -397,3 +397,90 @@ class TestEnvironmentScriptRunner:
                 assert arg0 == expected
                 arg1 = mock_cancel.call_args.args[1]
                 assert arg1 is time_limit
+
+    @pytest.mark.parametrize(
+        argnames="default_timeout",
+        argvalues=(
+            None,
+            timedelta(seconds=30),
+            timedelta(seconds=60),
+        ),
+    )
+    def test_run_env_action_passes_default_timeout(
+        self,
+        tmp_path: Path,
+        default_timeout: Optional[timedelta],
+    ) -> None:
+        # GIVEN
+        action = Action_2023_09(
+            command="{{ Task.Command }}",
+            args=["-c", "print('Hello')"],
+        )
+        script = EnvironmentScript_2023_09(
+            actions=EnvironmentActions_2023_09(
+                onExit=action,
+            )
+        )
+
+        symtab = SymbolTable(source={"Task.Command": sys.executable})
+        runner = EnvironmentScriptRunner(
+            logger=MagicMock(),
+            session_working_directory=tmp_path,
+            environment_script=script,
+            symtab=symtab,
+            session_files_directory=tmp_path,
+        )
+        with (
+            patch.object(runner, "_run_action") as mock_run_action,
+            runner,
+        ):
+            # WHEN
+            runner._run_env_action(
+                action=action,
+                default_timeout=default_timeout,
+            )
+
+        # THEN
+        mock_run_action.assert_called_once_with(
+            action,
+            symtab,
+            default_timeout=default_timeout,
+        )
+
+    def test_exit_uses_default_timeout(
+        self,
+        tmp_path: Path,
+    ):
+        # GIVEN
+        # An "onExit" action with no defined timeout
+        on_exit_action = Action_2023_09(
+            command="{{ Task.Command }}",
+            args=["-c", "print('Hello')"],
+        )
+        expected_default_timeout = timedelta(minutes=5)
+        script = EnvironmentScript_2023_09(
+            actions=EnvironmentActions_2023_09(
+                onExit=on_exit_action,
+            )
+        )
+
+        symtab = SymbolTable(source={"Task.Command": sys.executable})
+        runner = EnvironmentScriptRunner(
+            logger=MagicMock(),
+            session_working_directory=tmp_path,
+            environment_script=script,
+            symtab=symtab,
+            session_files_directory=tmp_path,
+        )
+        with (
+            patch.object(runner, "_run_env_action") as mock_run_env_action,
+            runner,
+        ):
+            # WHEN
+            runner.exit()
+
+        # THEN
+        mock_run_env_action.assert_called_once_with(
+            on_exit_action,
+            default_timeout=expected_default_timeout,
+        )


### PR DESCRIPTION
Fixes: #212

### What was the problem/requirement? (What/Why)

Previously when a `timeout` field was not specified on an`<Environment>` &rarr; `onExit` action, it implied that the environment exit action can run indefinitely. This was treated as a defect in the OpenJobDescription specification (see OpenJobDescription/openjd-specifications#70), since job schedulers may provide the ability to cancel jobs/steps/tasks and a reasonable default expectation should be that OpenJobDescription sessions are able to end and cleanup within a reasonable bound amount of time.

The OpenJobDescription specification was updated (see OpenJobDescription/openjd-specifications#72) and there is now a default timeout of 300 seconds, or five minutes, for `onExit` environment actions.

The `openjd-sessions` Python library needs to be updated to reflect this change in the OpenJobDescription specification.

### What was the solution? (How)

Modify how `openjd-sessions` applies a default timeout for environment exit actions. The `EnvironmentScriptRunner` and its base class `ScriptRunnerBase` were modified to add optional keyword arguments of `default_timeout` in the functions called when exiting an environment.

A constant was added for the new default timeout for environment exits which is used to supply this value in this special-case environment exit action type.

### What is the impact of this change?

The default timeout for environment exits will reflect the change to the OpenJobDescription specification and fix the defect in the `openjd-sessions` implementation.

### How was this change tested?

Added test coverage that all passes.

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

As an additional manual end-to-end test, I ran the following job template:

```yaml
# forever-env-exit.yaml
specificationVersion: 'jobtemplate-2023-09'
name: "Never-ending envExit"
jobEnvironments:
  - name: NeverEndingExitEnv
    script:
      actions:
        onEnter:
          command: echo
          args:
              - "Entering environment..."
        onExit:
          command: python
          args:
            - "{{ Env.File.Run }}"
      embeddedFiles:
        - name: Run
          type: TEXT
          runnable: True
          data: |
            #!/usr/bin/env python
            import time
            def main():
                print("Exiting environment...")
                while True:
                    time.sleep(1)
            if __name__ == "__main__":
              main()
steps:
- name: Main
  script:
    actions:
      onRun:
        command: echo
        args:
          - "Hello world"
```

using the OpenJD CLI command:

```
openjd run forever-env-exit.yaml --step Main
```

with this version of `openjd-sessions` used. Confirmed that the environment exit timed out with the following log output:

```txt
Thu Feb 20 21:52:18 2025        ==============================================
Thu Feb 20 21:52:18 2025        --------- Exiting Environment: NeverEndingExitEnv
Thu Feb 20 21:52:18 2025        ==============================================
Thu Feb 20 21:52:18 2025        ----------------------------------------------
Thu Feb 20 21:52:18 2025        Phase: Setup
Thu Feb 20 21:52:18 2025        ----------------------------------------------
Thu Feb 20 21:52:18 2025        Writing embedded files for Environment to disk.
Thu Feb 20 21:52:18 2025        Mapping: Env.File.Run -> /tmp/OpenJD/sample_sessioncy91ttji/embedded_filesz99feky9/tmp3y_boc86
Thu Feb 20 21:52:18 2025        Wrote: Run -> /tmp/OpenJD/sample_sessioncy91ttji/embedded_filesz99feky9/tmp3y_boc86
Thu Feb 20 21:52:18 2025        ----------------------------------------------
Thu Feb 20 21:52:18 2025        Phase: Running action
Thu Feb 20 21:52:18 2025        ----------------------------------------------
Thu Feb 20 21:52:18 2025        Running command /tmp/OpenJD/sample_sessioncy91ttji/tmpkl87cttt.sh
Thu Feb 20 21:52:18 2025        Command started as pid: 5549
Thu Feb 20 21:52:18 2025        Output:
Thu Feb 20 21:57:18 2025        TIMEOUT - Runtime limit reached at 2025-02-20T21:57:18Z. Canceling action.
Thu Feb 20 21:57:18 2025        Canceling subprocess 5549 via termination method at 2025-02-20T21:57:18Z.
Thu Feb 20 21:57:18 2025        INTERRUPT: Sending signal "kill" to process group 5549
Thu Feb 20 21:57:18 2025        Process pid 5549 exited with code: -9 (unsigned) / -0x9 (hex)
Thu Feb 20 21:57:18 2025        Open Job Description CLI: ERROR executing action: 'Exit Environment 'NeverEndingExitEnv'' (see Task logs for details)
Thu Feb 20 21:57:18 2025        Open Job Description CLI: Local Session ended! Now cleaning up Session resources.
```

As can be seen from the log messages and their timestamps, the action ran for five minutes before being timed out and canceled.

### Was this change documented?

Relevant docstrings were updated

### Is this a breaking change?

When a timeout is not specified for an environment exit it now has a timeout of 300 seconds or five minutes. Before
this change, environment exit actions would run indefinintely. To have long-running environment exit actions, job templates can specify a large timeout value when defining the action in a job or template.

This same message ☝️ was added in the `BREAKING CHANGE` conventional commit footer of the commit.

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*