### PR TITLE
chore!: Update to new openjd-model version and cleanup warnings

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,14 +37,14 @@ from any directory of this repository:
 * `hatch run fmt` - To automatically reformat all code to adhere to our formatting standards.
 * `hatch shell` - Enter a shell environment where you can run the `deadline` command-line directly as it is implemented in your
   checked-out local git repository.
-* `hatch env prune` - Delete all of your isolated workspace [environments](https://hatch.pypa.io/1.12/environment/) 
+* `hatch env prune` - Delete all of your isolated workspace [environments](https://hatch.pypa.io/1.12/environment/)
    for this package.
 
 If you are not sure about how to approach development for this package, then we have some suggestions.
 
 1. Run python within a `hatch shell` environment for interactive development. Python will import your in-development
    codebase when you `import openjd.session` from this environment. This makes it easy to use interactive python, the python
-   debugger, and short test scripts to develop and test your changes. 
+   debugger, and short test scripts to develop and test your changes.
    * Note that if you make changes to your source and are running interactive Python then you will need to use
     [importlib.reload](https://docs.python.org/3/library/importlib.html#importlib.reload) to reload the the module(s) that
     you modified for your modifications to take effect.
@@ -64,11 +64,12 @@ sometimes pruning (`hatch env prune`) all of these environments for the package 
 This module is responsible for providing functionality for a running Open Job Description Session.
 
 The public interface is via the `Session` class. An instance of this class represents a single
-running Session context, in the terms of the Open Job Description's Job Running Model.
+running Session context, in the terms of
+[How Open Job Description Jobs Are Run](https://github.com/OpenJobDescription/openjd-specifications/wiki/How-Jobs-Are-Run).
 
 The interface to a `Session` follows an asychronous computing model backed, internally,
 by threads. The `Session` has a state that gates what is able to be performed, and when.
-A user can begin running a new Action, whether that be the enter/exit of an Environment or 
+A user can begin running a new Action, whether that be the enter/exit of an Environment or
 the run-action of a Task, when the `Session` is in `READY` state. Running the action starts
 background threads that will monitor the running subprocess, and forward its stdout/stderr to
 a given Logger.
@@ -108,7 +109,7 @@ and invokes a callback in the `Session` when encountering one. This callback rec
 within the `Session`.
 
 The `LoggingSubprocess` has specialized logic for running the subprocess as a separate user depending on the
-operating system, and context in which it is being run. 
+operating system, and context in which it is being run.
 
 ## Testing
 
@@ -127,7 +128,7 @@ and [unitest.mock documentation](https://docs.python.org/3.8/library/unittest.mo
 
 Our tests are implemented using the [PyTest](https://docs.pytest.org/en/stable/) testing framework,
 and unit tests occationally make use of Python's [unittest.mock](https://docs.python.org/3.8/library/unittest.mock.html)
-package to avoid runtime dependencies and narrowly focus tests on a specific aspect of the implementation. 
+package to avoid runtime dependencies and narrowly focus tests on a specific aspect of the implementation.
 
 As a rule, we aim to keep usage of `unittest.mock` to a bare minimum in this package's tests. Using a mock inherrently
 encodes assumptions into the tests about how the mocked functionality functions. So, if a change is made that
@@ -199,7 +200,7 @@ password, that you are able to logon as. Then:
     * If done correctly, then you should not see any xfail tests related to impersonation.
 
 Run these tests in both:
-1. A terminal in your interactive logon session to test the impersonation logic when 
+1. A terminal in your interactive logon session to test the impersonation logic when
    Windows Session ID > 0; and
 2. An `ssh` terminal into your workstation to test the impersonation logic when Windows
    Session ID is 0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [
-  "openjd-model == 0.5.*",
+  "openjd-model == 0.6.*",
   "pywin32 == 308; platform_system == 'Windows'",
   "psutil >= 5.9,< 6.2; platform_system == 'Windows'",
 ]
@@ -99,7 +99,7 @@ mypy_path = "src"
 
 # See: https://docs.pydantic.dev/mypy_plugin/
 #  - Helps mypy understand pydantic typing.
-plugins = "pydantic.v1.mypy"
+plugins = "pydantic.mypy"
 
 [tool.ruff]
 line-length = 100

--- a/src/openjd/sessions/_runner_base.py
+++ b/src/openjd/sessions/_runner_base.py
@@ -7,7 +7,7 @@ import shlex
 from abc import ABC, abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 from threading import Lock, Timer
@@ -480,7 +480,7 @@ class ScriptRunnerBase(ABC):
         with self._lock:
             self._canceled = True
             self._notify_canceled_action_as_failed = mark_action_failed
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             now_str = now.strftime(TIME_FORMAT_STR)
             if self._cancel_gracetime_timer is not None:
                 # This cancel request is a duplicate that may have a different gracetime.
@@ -590,7 +590,7 @@ class ScriptRunnerBase(ABC):
             self._cancel_gracetime_timer = None
         self._logger.info(
             "Notify period ended. Terminate at %s",
-            datetime.utcnow().strftime(TIME_FORMAT_STR),
+            datetime.now(timezone.utc).strftime(TIME_FORMAT_STR),
             extra=LogExtraInfo(openjd_log_content=LogContent.PROCESS_CONTROL),
         )
         try:
@@ -612,7 +612,7 @@ class ScriptRunnerBase(ABC):
             self._runtime_limit = None
         self._logger.info(
             "TIMEOUT - Runtime limit reached at %s. Canceling action.",
-            datetime.utcnow().strftime(TIME_FORMAT_STR),
+            datetime.now(timezone.utc).strftime(TIME_FORMAT_STR),
             extra=LogExtraInfo(openjd_log_content=LogContent.PROCESS_CONTROL),
         )
         self._runtime_limit_reached = True

--- a/test/openjd/sessions/conftest.py
+++ b/test/openjd/sessions/conftest.py
@@ -139,7 +139,7 @@ def has_windows_user() -> bool:
     )
 
 
-def tests_are_in_windows_session_0() -> bool:
+def are_tests_in_windows_session_0() -> bool:
     return TEST_RUNNING_IN_WINDOWS_SESSION_0
 
 

--- a/test/openjd/sessions/test_runner_base.py
+++ b/test/openjd/sessions/test_runner_base.py
@@ -4,7 +4,7 @@ import json
 import os
 import sys
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging.handlers import QueueHandler
 from pathlib import Path
 from queue import SimpleQueue
@@ -59,7 +59,7 @@ class NotifyingRunner(ScriptRunnerBase):
     def cancel(
         self, *, time_limit: Optional[timedelta] = None, mark_action_failed: bool = False
     ) -> None:
-        self._cancel_called_at = datetime.utcnow()
+        self._cancel_called_at = datetime.now(timezone.utc)
         if time_limit is None:
             self._cancel(NotifyCancelMethod(timedelta(seconds=2)))
         else:
@@ -817,7 +817,7 @@ class TestScriptRunnerBase:
             # WHEN
             secs = 2 if not is_windows() else 5
             time.sleep(secs)  # Give the process a little time to do something
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             runner.cancel(time_limit=timedelta(seconds=2))
 
             # THEN
@@ -847,7 +847,9 @@ class TestScriptRunnerBase:
         assert len(notification_data) == 1
         assert "NotifyEnd" in notification_data
         assert notification_data["NotifyEnd"][-1] == "Z"
-        time_end = datetime.fromisoformat(notification_data["NotifyEnd"][:-1])
+        time_end = datetime.fromisoformat(notification_data["NotifyEnd"][:-1]).astimezone(
+            timezone.utc
+        )
         # Timestamp should be around 2s from cancel signal, but give a 1s window
         # for timing differences.
         delta_t = time_end - now

--- a/test/openjd/sessions/test_session_user.py
+++ b/test/openjd/sessions/test_session_user.py
@@ -14,7 +14,7 @@ from .conftest import (
     WIN_USERNAME_ENV_VAR,
     WIN_PASS_ENV_VAR,
     has_windows_user,
-    tests_are_in_windows_session_0,
+    are_tests_in_windows_session_0,
 )
 
 
@@ -22,7 +22,7 @@ from .conftest import (
 class TestWindowsSessionUser:
 
     @pytest.mark.skipif(
-        tests_are_in_windows_session_0(),
+        are_tests_in_windows_session_0(),
         reason="Cannot create a WindowsSessionUser with a password while in Session 0.",
     )
     @pytest.mark.parametrize(
@@ -40,7 +40,7 @@ class TestWindowsSessionUser:
         assert windows_session_user.user == user
 
     @pytest.mark.skipif(
-        tests_are_in_windows_session_0(),
+        are_tests_in_windows_session_0(),
         reason="Cannot create a WindowsSessionUser with a password while in Session 0.",
     )
     @pytest.mark.xfail(
@@ -68,7 +68,7 @@ class TestWindowsSessionUser:
             WindowsSessionUser("nonexistent_user")
 
     @pytest.mark.skipif(
-        tests_are_in_windows_session_0(),
+        are_tests_in_windows_session_0(),
         reason="Cannot create a WindowsSessionUser with a password while in Session 0.",
     )
     def test_incorrect_credential(self):

--- a/test/openjd/sessions/test_subprocess.py
+++ b/test/openjd/sessions/test_subprocess.py
@@ -23,7 +23,7 @@ from .conftest import (
     collect_queue_messages,
     has_posix_target_user,
     has_windows_user,
-    tests_are_in_windows_session_0,
+    are_tests_in_windows_session_0,
     WIN_SET_TEST_ENV_VARS_MESSAGE,
     POSIX_SET_TARGET_USER_ENV_VARS_MESSAGE,
 )
@@ -485,7 +485,9 @@ sys.exit(0)
         ]
 
         assert list_has_items_in_order(expected_messages, messages)
-        assert all(m not in messages for m in not_expected_messages)
+        assert all(
+            m not in messages for m in not_expected_messages
+        ), f"Unexpected messages: {', '.join(repr(m) for m in not_expected_messages if m in messages)}"
 
 
 def list_has_items_in_order(expected: list, actual: list) -> bool:
@@ -989,7 +991,7 @@ foreach ($envVar in $allEnvVars) {
         all_messages = []
         # conhost, python
         expected_num_child_procs: int = 2
-        if tests_are_in_windows_session_0():
+        if are_tests_in_windows_session_0():
             # Session 0 doesn't get the conhost process, so just:
             # python
             expected_num_child_procs = 1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Update for the released openjd-model version 0.6.

Running the tests produced deprecation and other warnings.

### What was the solution? (How)

* Update openjd-model to 0.6
* Change deprecated datetime.utcnow() usage to recommended datetime.now(timezone.utc)
* Rename test helper function tests_are_in_windows_session_0 to
  are_tests_in_windows_session_0 so that pytest doesn't try to run it as
  a test.
* Use pydantic.mypy instead of pydantic.v1.mypy to reflect the
      openjd-model update to Pydantic V2 in the type checking.

### What is the impact of this change?

Cleaning up warnings and updating dependencies.

### How was this change tested?

Ran the unit tests locally on Windows, but relying on the github actions tests for coverage.

### Was this change documented?

N/A

### Is this a breaking change?

    BREAKING CHANGE: The dependency openjd-model-for-python updated from
        Pydantic V1 to V2. See its changelog for details.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*