### PR TITLE
feat: Allow opt-in of running tasks after an env exit

### DIFF
--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -681,7 +681,11 @@ class Session(object):
         return identifier
 
     def exit_environment(
-        self, *, identifier: EnvironmentIdentifier, os_env_vars: Optional[dict[str, str]] = None
+        self,
+        *,
+        identifier: EnvironmentIdentifier,
+        os_env_vars: Optional[dict[str, str]] = None,
+        keep_session_running: bool = False,
     ) -> None:
         """Exits an Open Job Description Environment from this Session.
         This method is non-blocking; it will exit when the subprocess is either confirmed to have
@@ -699,6 +703,9 @@ class Session(object):
                 by values defined in Environments.
                     Key: Environment variable name
                     Value: Value for the environment variable.
+            keep_session_running (bool): This overrides the default of requiring only environment exits after
+                the first exit_environment is called. The caller can set this to True in order to exit
+                the environments of a step and then run tasks from a different step.
 
         Raises:
             ValueError - If the given identifier is not that of the next one that must be exited.
@@ -716,8 +723,9 @@ class Session(object):
 
         self._reset_action_state()
 
-        # Once we've started exiting environments, then we can only exit environments.
-        self._ending_only = True
+        # Unless overridden by the caller, once we've started exiting environments, then we can only exit environments.
+        if not keep_session_running:
+            self._ending_only = True
 
         environment = self._environments[identifier]
         log_section_banner(self._logger, f"Exiting Environment: {environment.name}")

--- a/test/openjd/sessions/test_session.py
+++ b/test/openjd/sessions/test_session.py
@@ -1674,6 +1674,90 @@ class TestSessionExitEnvironment_2023_09:  # noqa: N801
             assert session._runner is not None
             assert session._runner._os_env_vars == dict(variables1)
 
+    def test_run_task_after_env_exit(self) -> None:
+        # By default, tasks can't run after an environment exit. The exit_environment call
+        # can override that, however, and allow it.
+
+        # GIVEN
+        session_id = uuid.uuid4().hex
+        variables = {
+            "FOO": "corge",
+            "BAZ": "QUX",
+        }
+        environment = _make_environment(enter_script=False, exit_script=False, variables=variables)
+        step_script = StepScript_2023_09(
+            actions=StepActions_2023_09(
+                onRun=Action_2023_09(command=sys.executable, args=["{{ Task.File.Foo }}"])
+            ),
+            embeddedFiles=[
+                EmbeddedFileText_2023_09(
+                    name="Foo",
+                    type=EmbeddedFileTypes_2023_09.TEXT,
+                    data="print('Task running')",
+                )
+            ],
+        )
+        with Session(session_id=session_id, job_parameter_values={}) as session:
+            # WHEN Enter the environment and run a task
+            env_id = session.enter_environment(environment=environment)
+            while session.state == SessionState.RUNNING:
+                time.sleep(0.1)
+            session.run_task(step_script=step_script, task_parameter_values={})
+            # Wait for the process to exit
+            while session.state == SessionState.RUNNING:
+                time.sleep(0.1)
+
+            assert session.state == SessionState.READY
+
+            # THEN If we exit the environment with keep_session_running set, we can run another task
+            session.exit_environment(identifier=env_id, keep_session_running=True)
+            while session.state == SessionState.RUNNING:
+                time.sleep(0.1)
+
+            assert session.state == SessionState.READY
+            assert session.action_status == ActionStatus(
+                state=ActionState.SUCCESS,
+            )
+
+            # This should succeed
+            session.run_task(step_script=step_script, task_parameter_values={})
+            while session.state == SessionState.RUNNING:
+                time.sleep(0.1)
+
+            assert session.state == SessionState.READY
+
+            # WHEN Enter the environment again, and run a task
+            env_id = session.enter_environment(environment=environment)
+            while session.state == SessionState.RUNNING:
+                time.sleep(0.1)
+            session.run_task(step_script=step_script, task_parameter_values={})
+            while session.state == SessionState.RUNNING:
+                time.sleep(0.1)
+
+            assert session.state == SessionState.READY
+
+            # THEN If we exit the environment without keep_session_running set, we can't run another task
+            session.exit_environment(identifier=env_id)
+            while session.state == SessionState.RUNNING:
+                time.sleep(0.1)
+
+            # THEN
+            assert session.state == SessionState.READY_ENDING
+            assert session.action_status == ActionStatus(
+                state=ActionState.SUCCESS,
+            )
+
+            # This should fail
+            with pytest.raises(
+                RuntimeError, match="Session must be in the READY state to run a task."
+            ):
+                session.run_task(step_script=step_script, task_parameter_values={})
+
+            assert session.state == SessionState.READY_ENDING
+            assert session.action_status == ActionStatus(
+                state=ActionState.SUCCESS,
+            )
+
 
 class TestPathMapping_v2023_09:  # noqa: N801
     """Tests that path mapping works with the 2023-09 schema."""


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In order to fix https://github.com/OpenJobDescription/openjd-cli/issues/50, there needs to be a way to run tasks after an environment has exited. This change provides a way to do that in a backwards-compatible way.

### What was the solution? (How)

Add an optional `keep_session_running` parameter to the Session object's `exit_environment` function,
defaulting to the same behavior as before.

### What is the impact of this change?

We will be able to change the OpenJD CLI to fix the referenced issue.

### How was this change tested?

Added a test that confirms the behavior with and without this parameter set.

### Was this change documented?

Updated the docstring.

### Is this a breaking change?

No

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*