### PR TITLE
chore(deps): update openjd-model requirement from ==0.6.* to >=0.6,<0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries"
 ]
 dependencies = [
-  "openjd-model == 0.6.*",
+  "openjd-model >= 0.6,< 0.8",
   "pywin32 == 308; platform_system == 'Windows'",
   "psutil >= 5.9,< 7.1; platform_system == 'Windows'",
 ]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The openjd-model library released 0.7.0. The backwards-incompatible part of the release doesn't affect openjd-sessions.

### What was the solution? (How)

Expand the range of accepting openjd-model.

### What is the impact of this change?

Dependencies can use the latest releases.

### How was this change tested?

Ran unit tests.

### Was this change documented?

N/A

### Is this a breaking change?

No.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*