### PR TITLE
chore(deps): switch pywin32 to >= 307

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
   "openjd-model >= 0.6,< 0.8",
-  "pywin32 == 309; platform_system == 'Windows'",
+  "pywin32 >= 307; platform_system == 'Windows'",
   "psutil >= 5.9,< 7.1; platform_system == 'Windows'",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

See https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/pull/162. openjd-sessions is a library and will be more compatible with clients using it with fewer restrictions on dependencies.

### What was the solution? (How)

Update the pywin32 dependency to be '>= 307'. This matches the choice in https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/pull/162.

### What is the impact of this change?

Will be able to install the library in more contexts.

### How was this change tested?

Ran unit tests.

### Was this change documented?

N/A

### Is this a breaking change?

No

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*