### PR TITLE
chore: Add internal toggle to disable Running action banner

### DIFF
--- a/src/openjd/sessions/_runner_base.py
+++ b/src/openjd/sessions/_runner_base.py
@@ -225,6 +225,7 @@ class ScriptRunnerBase(ABC):
         # Will run at most the run futures
         self._pool = ThreadPoolExecutor(max_workers=1)
         self._state_override = None
+        self._print_section_banner = True
 
     # Context manager for use in our tests
     def __enter__(self) -> "ScriptRunnerBase":
@@ -354,7 +355,8 @@ class ScriptRunnerBase(ABC):
                 self._runtime_limit = Timer(time_limit.total_seconds(), self._on_timelimit)
                 self._runtime_limit.start()
 
-            log_subsection_banner(self._logger, "Phase: Running action")
+            if self._print_section_banner:
+                log_subsection_banner(self._logger, "Phase: Running action")
             self._run_future = self._pool.submit(self._process.run)
         # Intentionally leave the lock section. If the process was *really* fast,
         # then it's possible for the future to have finished before we get to add


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Currently the environment runners print a large banner as shown below when running actions. We would like to disable this banner for testing purposes. 

```
INFO     test_host_configuration.DetKHpyl<~_4]Woi?meTS!zT6r0q]sO&:_logging.py:89 ----------------------------------------------
INFO     test_host_configuration.DetKHpyl<~_4]Woi?meTS!zT6r0q]sO&:_logging.py:90 Phase: Running action
INFO     test_host_configuration.DetKHpyl<~_4]Woi?meTS!zT6r0q]sO&:_logging.py:91 ----------------------------------------------
```


### What was the solution? (How)
- Given the environment runner is a private API, added an internal flag to allow turning OFF the banner. 
  - The change explicitly does not add it to the constructor, or as a property. 
- As a follow up, I will also start discussions to make OpenJD Sessions a public API with a reviewed API contract.

### What is the impact of this change?
- Testability improvement and log readability.

### How was this change tested?
- hatch run test with test code. I can see the logs no longer show the banner.

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
Yes

### Was this change documented?
NA

### Is this a breaking change?
No

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the
[Public Interfaces](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#the-packages-public-interface) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*