### PR TITLE
Add script that runs tests as a Windows service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __pycache__/
 /build
 /dist
 _version.py
+*.log

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -205,7 +205,7 @@ Run these tests in both:
 2. Use the `scripts\windows_service_test.py` to test in the context of a service running session 0
    1. `hatch build`
    1. `pip install --force-reinstall dist\openjd_sessions*.whl`
-      1. `win32` doesn't work well in virtual environments, so it's more reliable to run with the system Python. The wheel file name will change depending the date and the version that the git branch is based off of.
+      1. `pywin32` doesn't work well in virtual environments, so it's more reliable to run with the system Python. The wheel file name will change depending the date and the version that the git branch is based off of.
    1. Install the service by running `python scripts\windows_service_test.py install --user-name <UserYouWantRunningTheService> --pytest-args="<AnyAdditionalPytestArgsYou'dWantToPassIn>"`
    1. Run the test in the service by running `python scripts\windows_service_test.py run`
    1. Test output is streamed to 'test.log' in the repository's root directory.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -208,7 +208,7 @@ Run these tests in both:
       1. `win32` doesn't work well in virtual environments, so it's more reliable to run with the system Python. The wheel file name will change depending the date and the version that the git branch is based off of.
    1. Install the service by running `python scripts\windows_service_test.py install --user-name <UserYouWantRunningTheService> --pytest-args="<AnyAdditionalPytestArgsYou'dWantToPassIn>"`
    1. Run the test in the service by running `python scripts\windows_service_test.py run`
-   1. You'll find the test output in the root project directory under `test.log`, the tests will live right to the log file.
+   1. Test output is streamed to 'test.log' in the repository's root directory.
 
 ### Super verbose test output
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -202,8 +202,13 @@ password, that you are able to logon as. Then:
 Run these tests in both:
 1. A terminal in your interactive logon session to test the impersonation logic when
    Windows Session ID > 0; and
-2. An `ssh` terminal into your workstation to test the impersonation logic when Windows
-   Session ID is 0.
+2. Use the `scripts\windows_service_test.py` to test in the context of a service running session 0
+   1. `hatch build`
+   1. `pip install --force-reinstall dist\openjd_sessions*.whl`
+      1. `win32` doesn't work well in virtual environments, so it's more reliable to run with the system Python. The wheel file name will change depending the date and the version that the git branch is based off of.
+   1. Install the service by running `python scripts\windows_service_test.py install --user-name <UserYouWantRunningTheService> --pytest-args="<AnyAdditionalPytestArgsYou'dWantToPassIn>"`
+   1. Run the test in the service by running `python scripts\windows_service_test.py run`
+   1. You'll find the test output in the root project directory under `test.log`, the tests will live right to the log file.
 
 ### Super verbose test output
 

--- a/scripts/windows_service_test.py
+++ b/scripts/windows_service_test.py
@@ -1,0 +1,162 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import socket
+import logging
+from threading import Event
+from typing import Optional
+
+import win32serviceutil
+import win32service
+import servicemanager
+import subprocess
+import sys
+import os
+import argparse
+import shlex
+import win32con
+import win32api
+from getpass import getpass
+
+
+logger = logging.getLogger(__name__)
+
+
+class OpenJDSessionsForPythonTestService(win32serviceutil.ServiceFramework):
+    # Pywin32 Service Configuration
+    _svc_name_ = "OpenJDSessionsForPythonTest"
+    _svc_display_name_ = "OpenJD Sessions For Python Test"
+    _exe_name_ = "OpenJDSessionsForPythonTestService.exe"
+
+    _stop_event: Event
+
+    def __init__(self, args):
+        win32serviceutil.ServiceFramework.__init__(self, args)
+
+        self._stop_event = Event()
+        socket.setdefaulttimeout(60)
+
+    def SvcStop(self):
+        """Invoked when the Windows Service is being stopped"""
+        self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
+        logger.info("Windows Service is being stopped")
+        self._stop_event.set()
+
+    def SvcShutdown(self):
+        """Invoked when the system is shutdown"""
+        self.SvcStop()
+
+    def SvcDoRun(self):
+        """The main entrypoint called after the service is started"""
+        servicemanager.LogMsg(
+            servicemanager.EVENTLOG_INFORMATION_TYPE,
+            servicemanager.PYS_SERVICE_STARTED,
+            (self._svc_name_, ""),
+        )
+        code_location = os.environ["CODE_LOCATION"]
+        pytest_args = os.environ.get("PYTEST_ARGS", None)
+
+        args = ["pytest", os.path.join(code_location, "test")]
+
+        if pytest_args:
+            args.extend(shlex.split(pytest_args, posix=False))
+
+        logging.basicConfig(
+            filename=os.path.join(code_location, "test.log"),
+            encoding="utf-8",
+            level=logging.INFO,
+            filemode="w",
+        )
+        process = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            cwd=code_location,
+        )
+
+        while True:
+            output = process.stdout.readline()
+            if not output and process.poll() is not None:
+                break
+
+            logger.info(output.strip())
+
+        servicemanager.LogMsg(
+            servicemanager.EVENTLOG_INFORMATION_TYPE,
+            servicemanager.PYS_SERVICE_STOPPED,
+            (self._svc_name_, ""),
+        )
+        logger.info("Stop status sent to Windows Service Controller")
+
+
+def _install_service(username: str, pytest_args: Optional[str] = None) -> list[str]:
+    if "\\" not in username and "@" not in username:
+        username = f".\\{username}"
+
+    password = getpass("Please enter the user's password:")
+    args = ["--username", username, "--password", password, "install"]
+
+    exe_args = [f"CODE_LOCATION={os.path.dirname(os.path.dirname(os.path.abspath(__file__)))}"]
+
+    if pytest_args:
+        exe_args.append(f"PYTEST_ARGS={pytest_args}")
+
+    key_handle = None
+    try:
+        # https://timgolden.me.uk/pywin32-docs/win32api__RegOpenKeyEx_meth.html
+        key_handle = win32api.RegOpenKeyEx(
+            getattr(win32con, "HKEY_LOCAL_MACHINE"),
+            f"SYSTEM\\CurrentControlSet\\Services\\{OpenJDSessionsForPythonTestService._svc_name_}",
+            0,  # reserved, only use 0
+            win32con.KEY_SET_VALUE,
+        )
+        # https://timgolden.me.uk/pywin32-docs/win32api__RegSetValueEx_meth.html
+        win32api.RegSetValueEx(
+            key_handle,
+            "Environment",
+            0,  # reserved, only use 0,
+            win32con.REG_MULTI_SZ,  # Multi-string value
+            exe_args,
+        )
+    finally:
+        if key_handle is not None:
+            win32api.CloseHandle(key_handle)
+
+    return args
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="Run OpenJD Sessions for Python Windows Service Tests",
+    )
+
+    # We wrap the commandline for win32serviceutil so that we can get the
+    # password from stdin instead of plaintext on the command line.
+    subparsers = parser.add_subparsers(dest="mode")
+
+    install_service_args = subparsers.add_parser("install")
+    install_service_args.add_argument("--username", required=True, type=str)
+    install_service_args.add_argument(
+        "--pytest-args",
+        required=False,
+        type=str,
+        dest="pytest_args",
+        default=None,
+        help='Use this with an equals like --pytest-args="-vvv". Otherwise the argument parser will not recognize the dash at the beginning (-)',
+    )
+
+    subparsers.add_parser("run")
+
+    args = parser.parse_args()
+
+    argv = [sys.argv[0]]
+
+    if args.mode == "install":
+        username = args.username
+
+        argv.extend(_install_service(username=username, pytest_args=args.pytest_args))
+
+    elif args.mode == "run":
+        argv.append("start")
+
+    win32serviceutil.HandleCommandLine(OpenJDSessionsForPythonTestService, argv=argv)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We're missing any easy way to run the tests as a Windows service. This is important because Windows has some different behaviour in session 0

### What was the solution? (How)

Add a script that installs the tests as a service, then runs them.

### What is the impact of this change?

Contributors can now run tests easily in session 0 directly as a service.

### How was this change tested?

Ran the tests with the script

### Was this change documented?

Ya

### Is this a breaking change?

Nope

### Does this change impact security?

Nope

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*