### PR TITLE
fix: cleanup session dir on windows

### DIFF
--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -48,6 +48,9 @@ from ._types import (
 )
 from ._version import version
 
+if is_windows():  # pragma: nocover
+    from subprocess import HIGH_PRIORITY_CLASS  # type: ignore
+
 if TYPE_CHECKING:
     from openjd.model.v2023_09._model import EnvironmentVariableObject
 
@@ -463,15 +466,11 @@ class Session(object):
                 if self._user is not None:
                     files = [str(f) for f in self.working_directory.glob("*")]
 
+                    creation_flags = None
                     if is_posix():
                         recursive_delete_cmd = ["rm", "-rf"]
                     else:
                         recursive_delete_cmd = [
-                            "start",
-                            '"Powershell"',
-                            "/high",
-                            "/wait",
-                            "/b",
                             "powershell",
                             "-Command",
                             "Remove-Item",
@@ -479,14 +478,18 @@ class Session(object):
                             "-Force",
                         ]
                         files = [", ".join(files)]
+                        # The cleanup needs to run as a high priority
+                        # https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getpriorityclass#return-value
+                        creation_flags = HIGH_PRIORITY_CLASS
 
-                    subprocess = LoggingSubprocess(
+                    _subprocess = LoggingSubprocess(
                         logger=self._logger,
                         args=recursive_delete_cmd + files,
                         user=self._user,
+                        creation_flags=creation_flags,
                     )
                     # Note: Blocking call until the process has exited
-                    subprocess.run()
+                    _subprocess.run()
 
                 self._working_dir.cleanup()
             except RuntimeError as exc:

--- a/src/openjd/sessions/_subprocess.py
+++ b/src/openjd/sessions/_subprocess.py
@@ -64,6 +64,7 @@ class LoggingSubprocess(object):
     _has_started: Event
     _os_env_vars: Optional[dict[str, Optional[str]]]
     _working_dir: Optional[str]
+    _creation_flags: Optional[int]
 
     _pid: Optional[int]
     _sudo_child_process_group_id: Optional[int]
@@ -79,6 +80,7 @@ class LoggingSubprocess(object):
         callback: Optional[Callable[[], None]] = None,
         os_env_vars: Optional[dict[str, Optional[str]]] = None,
         working_dir: Optional[str] = None,
+        creation_flags: Optional[int] = None,
     ):
         if len(args) < 1:
             raise ValueError("'args' kwarg must be a sequence of at least one element")
@@ -86,6 +88,8 @@ class LoggingSubprocess(object):
             raise ValueError("Argument 'user' must be a PosixSessionUser on posix systems.")
         if user is not None and is_windows() and not isinstance(user, WindowsSessionUser):
             raise ValueError("Argument 'user' must be a WindowsSessionUser on Windows systems.")
+        if not is_windows() and creation_flags is not None:
+            raise ValueError("Argument 'creation_flags' is only supported on Windows")
 
         self._logger = logger
         self._args = args[:]  # Make a copy
@@ -100,6 +104,7 @@ class LoggingSubprocess(object):
         self._pid = None
         self._returncode = None
         self._sudo_child_process_group_id = None
+        self._creation_flags = creation_flags
 
     @property
     def pid(self) -> Optional[int]:
@@ -274,6 +279,9 @@ class LoggingSubprocess(object):
                 # We need a process group in order to send notify signals
                 # https://docs.python.org/2/library/subprocess.html#subprocess.CREATE_NEW_PROCESS_GROUP
                 popen_args["creationflags"] = CREATE_NEW_PROCESS_GROUP
+
+                if self._creation_flags:
+                    popen_args["creationflags"] |= self._creation_flags
 
             # Get the command string for logging
             cmd_line_for_logger: str

--- a/test/openjd/sessions/test_runner_step_script.py
+++ b/test/openjd/sessions/test_runner_step_script.py
@@ -309,7 +309,9 @@ class TestStepScriptRunner:
         # GIVEN
         tmpdir = TempDir(user=windows_user)
         script = StepScript_2023_09(
-            actions=StepActions_2023_09(onRun=Action_2023_09(command=r"test.bat")),
+            actions=StepActions_2023_09(
+                onRun=Action_2023_09(command=CommandString_2023_09(r"test.bat"))
+            ),
             embeddedFiles=[
                 EmbeddedFileText_2023_09(
                     name="Foo",

--- a/test/openjd/sessions/test_subprocess.py
+++ b/test/openjd/sessions/test_subprocess.py
@@ -322,12 +322,14 @@ class TestLoggingSubprocessSameUser:
         all_messages = []
         # Note: This is the number of *CHILD* processes of the main process that we start.
         #  The total number of processes in flight will be this plus one.
-        expected_num_child_procs: int
-        if is_posix():
-            # Process tree: python -> python
-            # Children: python
-            expected_num_child_procs = 1
-        else:
+
+        # On Posix and on Windows not in a virutal environment:
+        # Process tree: python -> python
+        # Children: python
+        expected_num_child_procs = 1
+
+        # Check if we're in a virtual environment on Windows, see https://docs.python.org/3/library/venv.html#how-venvs-work
+        if is_windows() and sys.prefix != sys.base_prefix:
             # Windows starts an extra python process due to running in a virtual environment
             # Process tree: conhost -> python -> python -> python
             # Children: python, python, python
@@ -488,6 +490,18 @@ sys.exit(0)
         assert all(
             m not in messages for m in not_expected_messages
         ), f"Unexpected messages: {', '.join(repr(m) for m in not_expected_messages if m in messages)}"
+
+    @pytest.mark.skipif(is_windows(), reason="Posix-specific tests")
+    def test_creation_flags_posix(self, queue_handler: QueueHandler) -> None:
+
+        with pytest.raises(ValueError):
+            logger = build_logger(queue_handler)
+            LoggingSubprocess(
+                logger=logger,
+                args=[sys.executable, "-c", 'print("this should not run")'],
+                # Creation flags aren't supported on Posix systems.
+                creation_flags=1337,
+            )
 
 
 def list_has_items_in_order(expected: list, actual: list) -> bool:


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/410

### What was the problem/requirement? (What/Why)

Worker session cleanup encounters an error on windows when trying to delete the session directory

### What was the solution? (How)

We were calling the Powershell removal command with `start`, which is a Powershell command, not an executable. So this would crash the session cleanup every time on Windows. We still need to run the cleanup with high priority. The real solution is to add the creation flag `HIGH_PRIORITY_CLASS`. I added the ability to add creation flags to the `LoggerSubprocess`.

There were also a handful of issues with the tests that I fixed.

1. There was a test that was missed in the https://github.com/OpenJobDescription/openjd-sessions-for-python/pull/232 refactor
2. Sometimes we need to run the Windows tests outside a virtual environment, so this changes the behaviour of one of the tests.

### What is the impact of this change?

Sessions get cleaned up properly on Windows

### How was this change tested?

I ran the regular and user impersonation tests on Windows and Linux. I also tested through the worker agent.

Session output before change:

```
==============================================
--------- Session Cleanup
==============================================
Deleting working directory: C:\ProgramData\Amazon\OpenJD\session-25c4f9f3fbe4414384b86d8981719dcfwejr0z_b
Running command start \"Powershell\" /high /wait /b powershell -Command Remove-Item -Recurse -Force "C:\ProgramData\Amazon\OpenJD\session-25c4f9f3fbe4414384b86d8981719dcfwejr0z_b\embedded_files25i1ifkd, C:\ProgramData\Amazon\OpenJD\session-25c4f9f3fbe4414384b86d8981719dcfwejr0z_b\tmpaqtoehpa.json, C:\ProgramData\Amazon\OpenJD\session-25c4f9f3fbe4414384b86d8981719dcfwejr0z_b\tmpdchwv2x0.json, C:\ProgramData\Amazon\OpenJD\session-25c4f9f3fbe4414384b86d8981719dcfwejr0z_b\tmpu0q0y6fq.json"
Process failed to start: [WinError 2] The system cannot find the file specified.
```

Session output after change:

```
==============================================
--------- Session Cleanup
==============================================
Deleting working directory: C:\Sessions\session-dafe77e5d47d4deebe7563582702e3d51zn_0jlm
Running command powershell -Command Remove-Item -Recurse -Force "C:\Sessions\session-dafe77e5d47d4deebe7563582702e3d51zn_0jlm\embedded_filestm6icqi3, C:\Sessions\session-dafe77e5d47d4deebe7563582702e3d51zn_0jlm\tmp1aeck0dm.json, C:\Sessions\session-dafe77e5d47d4deebe7563582702e3d51zn_0jlm\tmpd4684tq8.json, C:\Sessions\session-dafe77e5d47d4deebe7563582702e3d51zn_0jlm\tmpv02146v8.json"
Command started as pid: 8612
Output:
Process pid 8612 exited with code: 0 (unsigned) / 0x0 (hex)
```

- Have you run the unit tests?
yes

### Was this change documented?

N/A

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*