### PR TITLE
test: testing containers failing to build

### DIFF
--- a/scripts/run_sudo_tests.sh
+++ b/scripts/run_sudo_tests.sh
@@ -60,7 +60,7 @@ pip_index_arg=""
 if test "${PIP_INDEX_URL:-}" != ""; then
     pip_index_arg="--build-arg PIP_INDEX_URL "
 fi
-docker build -t "${CONTAINER_IMAGE_TAG}" $pip_index_arg --build-arg "BUILDKIT_SANDBOX_HOSTNAME=${CONTAINER_HOSTNAME}" --file "testing_containers/${CONTAINER_IMAGE_DIR}/Dockerfile" .
+docker build -t "${CONTAINER_IMAGE_TAG}" $pip_index_arg --build-arg "BUILDKIT_SANDBOX_HOSTNAME=${CONTAINER_HOSTNAME}" --ulimit nofile=1024 --file "testing_containers/${CONTAINER_IMAGE_DIR}/Dockerfile" .
 
 if test "${BUILD_ONLY}" == "True"; then
     exit 0

--- a/testing_containers/ldap_sudo_environment/README.md
+++ b/testing_containers/ldap_sudo_environment/README.md
@@ -1,7 +1,7 @@
 
 ## Build
 ```
-docker build --build-arg BUILDKIT_SANDBOX_HOSTNAME=ldap.environment.internal -t openjd_ldap_test -f testing_containers/ldap_sudo_environment/Dockerfile .
+docker build --build-arg BUILDKIT_SANDBOX_HOSTNAME=ldap.environment.internal --ulimit nofile=1024 -t openjd_ldap_test -f testing_containers/ldap_sudo_environment/Dockerfile .
 ```
 
 ## Run Interactive Bash


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Linux testing containers were failing to build with a similar error to the one described here: https://github.com/rroemhild/docker-test-openldap/issues/51

### What was the solution? (How)
Same as the linked ticket above, add `--ulimit nofile=1024`
### What is the impact of this change?
The testing containers build again
### How was this change tested?
Ran the Linux tests on an AL2023 instance and verified that both Linux containers built again

- Have you run the unit tests?
No

### Was this change documented?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*