### PR TITLE
ci: update release workflows

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -8,6 +8,9 @@ on:
       branch:
         required: false
         type: string
+      tag:
+        required: false
+        type: string
 
 jobs:
   Test:
@@ -20,3 +23,4 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
+      ref: ${{inputs.tag}}

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -17,15 +17,8 @@ concurrency:
   group: release
 
 jobs:
-  UnitTests:
-    name: Unit Tests
-    uses: ./.github/workflows/code_quality.yml
-    with:
-      branch: mainline
-
   Bump:
     name: Version Bump
-    needs: UnitTests
     uses: OpenJobDescription/.github/.github/workflows/reusable_bump.yml@mainline
     secrets: inherit
     with:

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -1,5 +1,5 @@
 name: "Release: Publish"
-run-name: "Release: ${{ github.event.head_commit.message }}"
+run-name: "Release: ${{ github.event.head_commit.message || inputs.tag }}"
 
 on:
   push:
@@ -7,18 +7,62 @@ on:
       - mainline
     paths:
       - CHANGELOG.md
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: Specify a tag to re-run a release.
 
 concurrency:
   group: release
 
+permissions:
+  contents: read
+
 jobs:
+  TagRelease:
+    uses: OpenJobDescription/.github/.github/workflows/reusable_tag_release.yml@mainline
+    secrets: inherit
+    with:
+      tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+
+  UnitTests:
+    name: Unit Tests
+    needs: TagRelease
+    uses: ./.github/workflows/code_quality.yml
+    with:
+      tag: ${{ needs.TagRelease.outputs.tag }}
+
+  PreRelease:
+      needs: [TagRelease, UnitTests]
+      uses: OpenJobDescription/.github/.github/workflows/reusable_prerelease.yml@mainline
+      permissions:
+        id-token: write
+        contents: write
+      secrets: inherit
+      with:
+          tag: ${{ needs.TagRelease.outputs.tag }}
+
+  Release:
+      needs: [TagRelease, PreRelease]
+      uses: OpenJobDescription/.github/.github/workflows/reusable_release.yml@mainline
+      secrets: inherit
+      permissions:
+        id-token: write
+        contents: write
+      with:
+          tag: ${{ needs.TagRelease.outputs.tag }}
+
   Publish:
-    name: Publish Release
+    needs: [TagRelease, Release]
+    uses: OpenJobDescription/.github/.github/workflows/reusable_publish_python.yml@mainline
     permissions:
       id-token: write
-      contents: write
-    uses: OpenJobDescription/.github/.github/workflows/reusable_publish.yml@mainline
     secrets: inherit
+    with:
+        tag: ${{ needs.TagRelease.outputs.tag }}
+
   # PyPI does not support reusable workflows yet
   # # See https://github.com/pypi/warehouse/issues/11096
   PublishToPyPI:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The re-usable workflows for the release process have been made more modular. In addition we are now doing tag based releases. We need to update the release workflows in the repository to use new new modular re-usable workflows.

https://github.com/OpenJobDescription/.github/pull/7

### What was the solution? (How)
1. Add tag support to workflows
2. Remove Unit Tests from Bump workflow. These are redundant since the tests will run in the changelog PR and on the tagged release.
3. Update the release workflow to use the modular workflows

### What is the impact of this change?
1. Calling for a code freeze is no longer required to do a release.
2. The release workflow can now be re-run by specifying an existing that that does not have an associated GitHub Release.
3. Release utilizes a tag for testing/building instead of mainline HEAD.

### How was this change tested?

Tested in a [developer fork](https://github.com/moorec-aws/openjd-model-for-python/actions/runs/15544888123)

### Was this change documented?

n/a

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*