### PR TITLE
chore: Allow zero version when releasing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,7 @@ fail_under = 79
 # Can be removed or set to true once we are v1
 major_on_zero = false
 tag_format = "{version}"
+allow_zero_version = true
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Project major version is automatically bumped when releasing

### What was the solution? (How)
Add `allow_zero_version = true` to semantic release settings

### What is the impact of this change?
No unwanted major version bump :)

### How was this change tested?
n/a, project configuration change

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
Yes just in case

### Was this change documented?
n/a


### Is this a breaking change?
definitely not

### Does this change impact security?
nop
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*