### PR TITLE
test: timezone information was dropped when parsing the cancel NotifyEnd

### DIFF
--- a/test/openjd/sessions/test_runner_base.py
+++ b/test/openjd/sessions/test_runner_base.py
@@ -862,8 +862,9 @@ class TestScriptRunnerBase:
         assert len(notification_data) == 1
         assert "NotifyEnd" in notification_data
         assert notification_data["NotifyEnd"][-1] == "Z"
-        time_end = datetime.fromisoformat(notification_data["NotifyEnd"][:-1]).astimezone(
-            timezone.utc
+        # Stripping the Z removes timezone information. Need to ensure it's not interpreted as local
+        time_end = datetime.fromisoformat(notification_data["NotifyEnd"][:-1]).replace(
+            tzinfo=timezone.utc
         )
         # Timestamp should be around 2s from cancel signal, but give a 1s window
         # for timing differences.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1 test was failing locally for me on my macOS machine - `test_cancel_notify`. 

```
FAILED test/openjd/sessions/test_runner_base.py::TestScriptRunnerBase::test_cancel_notify - assert datetime.timedelta(seconds=18001, microseconds=361076) < datetime.timedelta(seconds=3)
```

hint: 18000seconds is 5 hours or GMT-5

At first i thought there was some nuance in datetimes on macOS vs. other OSes. But it turns out that this fails on Windows too if the timezone for the machine isn't UTC.

### What was the solution? (How)

We were dropping the timezone information ('Z') from the cancel notify file and so python was interpreting it as the local time before then changing to UTC. Didn't discover this previously since all of our runners are on UTC.

### What is the impact of this change?

All non-cross-user tests run locally on macOS (and other OSes if you're not in UTC)!

### How was this change tested?

```
hatch run test
...
==== 472 passed, 26 skipped, 15 xfailed in 44.25s ====
```

### Was this change documented?

N/A

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*