### PR TITLE
chore: Revert "chore: pin the version of click that hatch uses to <8.…

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -83,7 +83,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "click<8.3"
+          pip install --upgrade hatch
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "click<8.3"
+pip install --upgrade hatch
 pip install --upgrade twine
 hatch run codebuild:lint
 hatch run codebuild:test


### PR DESCRIPTION
…3 due to Sentin… (#272)"

### What was the problem/requirement? (What/Why)

Hatch has fixed an issue with it's click dependency. We no longer need to pin click.
Hatch Release: https://github.com/pypa/hatch/releases/tag/hatch-v1.14.2

### What was the solution? (How)
This reverts commit b40ee64ca61cdf27e96d27a8c7f4000d91164538.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
