### PR TITLE
ci: Add Python versions 3.13 and 3.14 to the github action test matrix

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     uses: OpenJobDescription/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Github action tested Python only to 3.12.

### What was the solution? (How)

Add 3.13 and 3.14 to the list.

### What is the impact of this change?

Ensure compatibility with recent Python versions.

### How was this change tested?

Tests running in PR.

### Was this change documented?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*