### PR TITLE
docs: python 3.13 and 3.14

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -21,7 +21,7 @@ lint = [
 ]
 
 [[envs.all.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [envs.container.env-vars]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Our actions run on python 3.13 and 3.14, but nothing in our docs/package say we explicitly support these versions

### What was the solution? (How)

Update docs

### What is the impact of this change?

N/A

### How was this change tested?

```
hatch run test:all
```

### Was this change documented?

This is the documentation :)

### Is this a breaking change?

N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*