### PR TITLE
test: cancel notify - message immediately after 'Trapped' may not be digit

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -5,7 +5,7 @@ pre-install-commands = [
 
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
-test = "pytest --cov-config pyproject.toml {args:test}"
+test = "pytest --cov-config pyproject.toml {args}"
 typing = "mypy {args:src test}"
 style = [
   "ruff check {args:.}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,9 @@ line-length = 100
 
 [tool.pytest.ini_options]
 xfail_strict = false
+testpaths = [
+    "test"
+]
 addopts = [
     "-rfEx",
     "--durations=5",

--- a/test/openjd/sessions/test_runner_base.py
+++ b/test/openjd/sessions/test_runner_base.py
@@ -822,6 +822,7 @@ class TestScriptRunnerBase:
         # Test that NOTIFY_THEN_CANCEL first signals a SIGTERM and then a SIGKILL
 
         # GIVEN
+        proc_id: Optional[int] = None
         logger = build_logger(queue_handler)
         with NotifyingRunner(logger=logger, session_working_directory=tmp_path) as runner:
             python_app_loc = (
@@ -833,6 +834,11 @@ class TestScriptRunnerBase:
             secs = 2 if not is_windows() else 5
             time.sleep(secs)  # Give the process a little time to do something
             now = datetime.now(timezone.utc)
+
+            assert runner._process is not None
+            assert runner._process._pid is not None
+            proc_id = runner._process._pid
+
             runner.cancel(time_limit=timedelta(seconds=2))
 
             # THEN
@@ -849,9 +855,12 @@ class TestScriptRunnerBase:
         messages = collect_queue_messages(message_queue)
         assert "Trapped" in messages
         trapped_idx = messages.index("Trapped")
+        process_exit_idx = messages.index(
+            f"Process pid {proc_id} exited with code: {runner.exit_code} (unsigned) / {hex(runner.exit_code)} (hex)"
+        )
         # Should be at least one more number printed after the Trapped
         # to indicate that we didn't immediately terminate the script.
-        assert messages[trapped_idx + 1].isdigit()
+        assert any(msg.isdigit() for msg in messages[trapped_idx + 1 : process_exit_idx])
         # Didn't get to the end
         assert "Log from test 9" not in messages
         # Notification file exists


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Seen here: https://github.com/OpenJobDescription/openjd-sessions-for-python/actions/runs/20624606046/job/59232920551

```
18:14:10.089 INFO          _logging.py:89  ----------------------------------------------
18:14:10.090 INFO          _logging.py:90  Phase: Running action
18:14:10.090 INFO          _logging.py:91  ----------------------------------------------
18:14:10.090 INFO       _subprocess.py:297 Running command C:\Users\runneradmin\AppData\Local\hatch\env\virtual\openjd-sessions\QNF-saPu\openjd-sessions\Scripts\python.exe D:\a\openjd-sessions-for-python\openjd-sessions-for-python\test\openjd\sessions\support_files\app_20s_run_ignore_signal.py
18:14:10.093 INFO       _subprocess.py:188 Command started as pid: 6128
18:14:10.093 INFO       _subprocess.py:192 Output:
18:14:10.140 INFO       _subprocess.py:401 0
18:14:11.154 INFO       _subprocess.py:401 1
18:14:12.156 INFO       _subprocess.py:401 2
18:14:13.157 INFO       _subprocess.py:401 3
18:14:14.166 INFO       _subprocess.py:401 4
18:14:15.101 INFO      _runner_base.py:510 Canceling subprocess 6128 via notify then terminate method at 2025-12-31T18:14:15Z.
18:14:15.101 INFO      _runner_base.py:539 Grace period ends at 2025-12-31T18:14:17Z
18:14:15.101 INFO       _subprocess.py:613 INTERRUPT: Sending CTRL_BREAK_EVENT to 6128
18:14:15.103 INFO       _subprocess.py:297 Running command c:\users\runneradmin\appdata\local\hatch\env\virtual\openjd-sessions\qnf-sapu\openjd-sessions\scripts\python.exe D:\a\openjd-sessions-for-python\openjd-sessions-for-python\src\openjd\sessions\_scripts\_windows\_signal_win_subprocess.py 6128
18:14:15.105 INFO       _subprocess.py:188 Command started as pid: 4532
18:14:15.105 INFO       _subprocess.py:192 Output:
18:14:15.181 INFO       _subprocess.py:401 Trapped
18:14:15.181 INFO       _subprocess.py:441 Process pid 4532 exited with code: 0 (unsigned) / 0x0 (hex)
18:14:15.181 INFO       _subprocess.py:401 5
18:14:16.183 INFO       _subprocess.py:401 6
18:14:17.185 INFO       _subprocess.py:401 7
18:14:17.196 INFO      _runner_base.py:593 Notify period ended. Terminate at 2025-12-31T18:14:17Z
18:14:17.196 INFO       _subprocess.py:241 INTERRUPT: Start killing the process tree with the root pid: 6128
18:14:17.202 INFO _windows_process_killer.py:84  Killing process with id 3168.
18:14:17.202 INFO _windows_process_killer.py:84  Killing process with id 6128.
18:14:17.212 INFO       _subprocess.py:441 Process pid 6128 exited with code: 15 (unsigned) / 0xf (hex)
```

The test expects that the message after "Trapped" is a digit, but this is time sensitive, so it's possible for the cancellation process to exit before the sleep process prints out the next number.

### What was the solution? (How)

Change the assertions to check for digits any time before the targeted process exits

### What is the impact of this change?

More robust tests

### How was this change tested?

It's a timing issue, so I was unable to reproduce locally, but I ran 

```
hatch run test
```
and confirmed it still passes locally.

### Was this change documented?

N/A

### Is this a breaking change?

N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*