### PR TITLE
feat: Add OPENJD_SESSION_WORKING_DIR environment variable

### DIFF
--- a/src/openjd/sessions/_session.py
+++ b/src/openjd/sessions/_session.py
@@ -452,6 +452,10 @@ class Session(object):
             extra=LogExtraInfo(openjd_log_content=LogContent.FILE_PATH),
         )
 
+        # Expose working directory as env var for nested subprocesses that can't access template variables.
+        # This env var is part of the public API — removing or renaming it is a breaking change.
+        self._process_env["OPENJD_SESSION_WORKING_DIR"] = str(self.working_directory)
+
         self._state = SessionState.READY
 
     def cleanup(self) -> None:

--- a/test/openjd/sessions/test_session.py
+++ b/test/openjd/sessions/test_session.py
@@ -136,6 +136,23 @@ class TestSessionInitialization:
 
         session.cleanup()
 
+    def test_initialize_sets_working_dir_env_var(self) -> None:
+        # OPENJD_SESSION_WORKING_DIR is part of the public API — removing or renaming it is a breaking change.
+        # This test ensures the env var contract is maintained.
+
+        # GIVEN
+        session_id = uuid.uuid4().hex
+        job_params = dict[str, ParameterValue]()
+
+        # WHEN
+        session = Session(session_id=session_id, job_parameter_values=job_params)
+
+        # THEN
+        assert "OPENJD_SESSION_WORKING_DIR" in session._process_env
+        assert session._process_env["OPENJD_SESSION_WORKING_DIR"] == str(session.working_directory)
+
+        session.cleanup()
+
     @pytest.mark.usefixtures("tmp_path")  # built-in fixture
     def test_initialize_with_root_dir(self, tmp_path: Path) -> None:
         # Test that we create the Session Working Directory in the given directory, if there is one.
@@ -927,7 +944,13 @@ class TestSessionRunTask_2023_09:  # noqa: N801
             # THEN
             assert session._runner is not None
             assert fix_foo_baz_environment.variables is not None
-            assert session._runner._os_env_vars == dict(fix_foo_baz_environment.variables)
+            # Check that environment variables are present (superset check to allow for
+            # session-injected vars like OPENJD_SESSION_WORKING_DIR)
+            assert session._runner._os_env_vars is not None
+            assert (
+                dict(fix_foo_baz_environment.variables).items()
+                <= session._runner._os_env_vars.items()
+            )
 
 
 class TestSessionCancel:
@@ -1401,7 +1424,10 @@ class TestSessionEnterEnvironment_2023_09:  # noqa: N801
                 time.sleep(0.1)
             assert session.state == SessionState.READY
             assert session._runner is not None
-            assert session._runner._os_env_vars == dict(variables)
+            # Check that environment variables are present (superset check to allow for
+            # session-injected vars like OPENJD_SESSION_WORKING_DIR)
+            assert session._runner._os_env_vars is not None
+            assert dict(variables).items() <= session._runner._os_env_vars.items()
 
     @pytest.mark.usefixtures("caplog")  # builtin fixture
     def test_enter_environment_with_resolved_variables(
@@ -1471,7 +1497,10 @@ class TestSessionEnterEnvironment_2023_09:  # noqa: N801
                 time.sleep(0.1)
 
             assert session._runner is not None
-            assert session._runner._os_env_vars == dict(variables2)
+            # Check that environment variables are present (superset check to allow for
+            # session-injected vars like OPENJD_SESSION_WORKING_DIR)
+            assert session._runner._os_env_vars is not None
+            assert dict(variables2).items() <= session._runner._os_env_vars.items()
 
 
 class TestSessionExitEnvironment_2023_09:  # noqa: N801
@@ -1763,7 +1792,9 @@ class TestSessionExitEnvironment_2023_09:  # noqa: N801
             # THEN
             assert session.state == SessionState.READY_ENDING
             assert session._runner is not None
-            assert session._runner._os_env_vars == dict(variables)
+            # Check that environment variables are present (superset check to allow for
+            # session-injected vars like OPENJD_SESSION_WORKING_DIR)
+            assert dict(variables).items() <= session._runner._os_env_vars.items()
 
     def test_exit_two_environments_with_variables(self, python_exe: str) -> None:
         # GIVEN
@@ -1798,7 +1829,9 @@ class TestSessionExitEnvironment_2023_09:  # noqa: N801
             # THEN
             assert session.state == SessionState.READY_ENDING
             assert session._runner is not None
-            assert session._runner._os_env_vars == dict(variables2)
+            # Check that environment variables are present (superset check to allow for
+            # session-injected vars like OPENJD_SESSION_WORKING_DIR)
+            assert dict(variables2).items() <= session._runner._os_env_vars.items()
 
             session.exit_environment(identifier=identifier1)
             # Wait for the process to exit
@@ -1808,7 +1841,9 @@ class TestSessionExitEnvironment_2023_09:  # noqa: N801
             # THEN
             assert session.state == SessionState.READY_ENDING
             assert session._runner is not None
-            assert session._runner._os_env_vars == dict(variables1)
+            # Check that environment variables are present (superset check to allow for
+            # session-injected vars like OPENJD_SESSION_WORKING_DIR)
+            assert dict(variables1).items() <= session._runner._os_env_vars.items()
 
     def test_run_task_after_env_exit(self, python_exe: str) -> None:
         # By default, tasks can't run after an environment exit. The exit_environment call


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The session working directory is only accessible via the template variable {{Session.WorkingDirectory}}, which gets resolved at template evaluation time. Nested subprocesses (like DCC activate scripts spawning helper processes) can't access template variables; they need an actual OS environment variable. 

### What was the solution? (How)
Expose the session working directory as an environment variable so that nested subprocesses can access it. Template variables like {{Session.WorkingDirectory}} are only available at template evaluation time, but this env var propagates to all child processes.

- Add OPENJD_SESSION_WORKING_DIR to _process_env in Session.__init__
- Update 5 existing tests to use superset checks for env var assertions
- Add new test to verify the env var is set correctly

Added current change to OpenJD Spec as well: https://github.com/OpenJobDescription/openjd-specifications/pull/137

### What is the impact of this change?
This change exposes the working directory as OPENJD_SESSION_WORKING_DIR so all child processes can access it.

### How was this change tested?

Ran all unit tests, as well added new ones
```
============================================================================================================ 529 passed, 28 skipped, 16 xfailed in 41.95s ============================================================================================================

```

### Was this change documented?
A brief inline comment was added explaining the purpose of the new env var:

```
# Expose working directory as env var for nested subprocesses that can't access template variables
self._process_env["OPENJD_SESSION_WORKING_DIR"] = str(self.working_directory)
```

### Is this a breaking change?
No. This is an additive change that introduces a new environment variable. No existing public interfaces are modified, and no user action is required.

### Does this change impact security?

No. The working directory path is already accessible via the {{Session.WorkingDirectory}} template variable and the session.working_directory property. This change simply exposes the same value through an additional mechanism (environment variable). No new files or directories are created, and no permissions are modified.

### Environment Variable Flow
```
Session.__init__()
    │
    ├── os_env_vars passed in (e.g., DEADLINE_* vars from worker agent)
    │
    ├── self._process_env = dict(os_env_vars)  # Base env dict
    │
    ├── Working directory created
    │
    ├── self._process_env["OPENJD_SESSION_WORKING_DIR"] = str(self.working_directory)  ← NEW
    │
    └── State set to READY

Session.run_task() / enter_environment() / exit_environment()
    │
    └── _evaluate_current_session_env_vars()
            │
            ├── Starts with self._process_env as base  ← Contains our new env var
            ├── Layers on environment-specific vars
            └── Returns final env dict for subprocess
                    │
                    └── Subprocess inherits OPENJD_SESSION_WORKING_DIR
                            └── Child processes also inherit it
```

### Insertion Point

File: src/openjd/sessions/_session.py
Location: Session.__init__(), after working directory is created and logged, before state is set to READY (~line 453)

```
self._logger.info(
    f"Session's Embedded Files Directory: {str(self.files_directory)}",
    ...
)

# Expose working directory as env var for nested subprocesses that can't access template variables
self._process_env["OPENJD_SESSION_WORKING_DIR"] = str(self.working_directory)

self._state = SessionState.READY
```
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*