### PR TITLE
feat: add support for domain users

### DIFF
--- a/src/openjd/sessions/_session_user.py
+++ b/src/openjd/sessions/_session_user.py
@@ -1,6 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import os
+import sys
+from functools import lru_cache
 from typing import Optional
 from abc import ABC, abstractmethod
 from ctypes.wintypes import HANDLE
@@ -40,6 +42,13 @@ class BadCredentialsException(Exception):
     pass
 
 
+@lru_cache(maxsize=1)
+def _get_process_user_sid():
+    """Returns the SID of the current process user. Cached since it never changes."""
+    sid, _, _ = win32security.LookupAccountName(None, get_process_user())
+    return sid
+
+
 class SessionUser(ABC):
     """Base class for holding information on the specific os-user identity to run
     a Session as.
@@ -62,7 +71,16 @@ class SessionUser(ABC):
         """
         Returns True if the session user is the user running the current process, else False.
 
+        On Windows, this uses SID comparison to correctly handle different username formats
+        (e.g. UPN "user@domain.com" vs DDL "DOMAIN\\user") that refer to the same account.
         """
+        if sys.platform == "win32":
+            try:
+                user_sid, _, _ = win32security.LookupAccountName(None, self.user)
+                return user_sid == _get_process_user_sid()
+            except pywintypes.error:
+                # Fall back to string comparison if SID lookup fails
+                return self.user == self._get_process_user()
         return self.user == self._get_process_user()
 
 

--- a/src/openjd/sessions/_win32/_helpers.py
+++ b/src/openjd/sessions/_win32/_helpers.py
@@ -70,10 +70,16 @@ def logon_user(username: str, password: str) -> HANDLE:
     Raises:
         OSError - If an error is encountered.
     """
+    domain: Optional[str] = None
+    user = username
+    if "\\" in username:
+        domain, user = username.split("\\", 1)
+    # For UPN (user@domain) and local users, domain stays None — Windows resolves automatically
+
     hToken = HANDLE(0)
     if not LogonUserW(
-        username,
-        None,  # TODO - domain handling??
+        user,
+        domain,
         password,
         LOGON32_LOGON_INTERACTIVE,
         LOGON32_PROVIDER_DEFAULT,

--- a/src/openjd/sessions/_win32/_popen_as_user.py
+++ b/src/openjd/sessions/_win32/_popen_as_user.py
@@ -168,10 +168,16 @@ class PopenWindowsAsUser(Popen):
                     else:
                         env_block = env_ptr
 
+                # Parse domain from username for CreateProcessWithLogonW
+                _logon_user = self.user.user
+                _logon_domain = None
+                if "\\" in self.user.user:
+                    _logon_domain, _logon_user = self.user.user.split("\\", 1)
+
                 # https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createprocesswithlogonw
                 if not CreateProcessWithLogonW(
-                    self.user.user,
-                    None,  # TODO: Domains not yet supported
+                    _logon_user,
+                    _logon_domain,
                     self.user.password,
                     LOGON_WITH_PROFILE,
                     executable,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

  The sessions library did not support Windows domain users. `LogonUserW` and `CreateProcessWithLogonW`
  were called without parsing the domain component from the username, and `is_process_user()` used
  string equality which fails when comparing different formats of the same account (e.g. UPN
  `user@domain.com` vs DDL `DOMAIN\user`).

  ### What was the solution? (How)

  1. **`_helpers.py` / `_popen_as_user.py`** — Parse DDL-format usernames (`DOMAIN\user`) into separate
  domain and user components before passing to `LogonUserW` and `CreateProcessWithLogonW`. UPN
  (`user@domain.com`) and local usernames are passed with `d: main=None`, which Windows resolves
  natively: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-logonuserw:

> If you use the [user principal name](https://learn.microsoft.com/en-us/windows/desktop/SecGloss/u-gly) (UPN) format, User@DNSDomainName, the lpszDomain parameter must be NULL.

  2. **`_session_user.py`** — Replace string comparison in `is_process_user()` with SID-based comparison
  using `LookupAccountName`. This correctly identifies that `user@domain.com` and `DOMAIN\user` refer to
  the same account. The process user's SID is cached via `lru_cache` since it never changes. Falls back
  to string comparison if SID lookup fails.

  ### What is the impact of this change?

  Enables the sessions library to run subprocesses as domain users in both DDL (`DOMAIN\user`) and UPN
  (`user@domain.com`) formats. This is required by the Deadline Cloud Worker Agent for Active Directory
  environments.

  ### How was this change tested?

  - E2E tests in the worker agent repo (`test_domain_user.py`) parameterized across DDL and UPN formats,
  verifying jobs run as both local and domain queue users with job attachments.
  - Manual testing on a Windows Server 2022 EC2 instance promoted to a domain controller.

  - Have you run the unit tests?
  Yes

  ### Was this change documented?

  - Are relevant docstrings in the code base updated?
  
  Yes — `is_process_user()` docstring updated to
  describe SID comparison behavior.

  ### Is this a breaking change?

  No. The public interface of `WindowsSessionUser` is unchanged. The `user` parameter now accepts domain
  usernames (DDL and UPN) in addition to local usernames, which is additive.

### Does this change impact security?

Nope, using same APIs