### PR TITLE
docs(template): add openjd-rs cross-port checklist to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,17 @@ If so, then please describe the changes that users of this package must make to 
 - Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
     - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.
 
+### Cross-port to openjd-rs
+
+This package is being migrated to Rust in [`openjd-rs/crates/openjd-sessions`](https://github.com/OpenJobDescription/openjd-rs/tree/main/crates/openjd-sessions).
+Behavioral changes made here should be replicated there to keep the two
+implementations in sync until the migration is complete.
+
+- [ ] This change does not affect runtime behavior (docs / tests / tooling only), **or**
+- [ ] A matching change has been opened in `openjd-rs` (link the PR here): *<insert link>*, **or**
+- [ ] A tracking issue has been filed in `openjd-rs` to port this change (link here): *<insert link>*, **or**
+- [ ] Cross-porting is not applicable for this change because: *<reason>*
+
 ----
 
 *By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*


### PR DESCRIPTION
Fixes: *N/A — internal process improvement, no GitHub issue tracked*

### What was the problem/requirement? (What/Why)

This package is being migrated to a Rust implementation at [`openjd-rs/crates/openjd-sessions`](https://github.com/OpenJobDescription/openjd-rs/tree/main/crates/openjd-sessions). Until the migration completes, the two implementations need to stay behaviorally in sync. Today there is no reminder in the PR workflow to replicate behavioral changes to the Rust port, which makes it easy for the implementations to drift unintentionally.

### What was the solution? (How)

Add a "Cross-port to openjd-rs" section to `.github/PULL_REQUEST_TEMPLATE.md` with a checklist that asks the PR author to pick one of:

- This change does not affect runtime behavior (docs / tests / tooling only), or
- A matching change has been opened in `openjd-rs` (with a link), or
- A tracking issue has been filed in `openjd-rs` (with a link), or
- Cross-porting is not applicable for this change, with a stated reason.

The checklist is mutually exclusive — every PR has to consciously make a choice rather than skipping the question.

### What is the impact of this change?

- PR template only. No code or runtime behavior changes.
- New PRs against this repo will see the additional checklist when they open a pull request.
- Existing open PRs are not affected.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
  
  N/A — this PR only modifies the GitHub PR template (`.github/PULL_REQUEST_TEMPLATE.md`). There is no executable code to test. Verified by rendering the markdown locally to confirm the new section reads correctly and the checkboxes render as expected.

### Was this change documented?

- Are relevant docstrings in the code base updated?
  
  N/A — no source code changed. The template itself is the documentation.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the [Public Interfaces](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#the-packages-public-interface) section of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

No. The change is to the GitHub PR template only. No public Python interface, configuration, or runtime behavior changes.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No security impact. Editing `.github/PULL_REQUEST_TEMPLATE.md` only changes the prefilled body text shown to PR authors; it does not affect file permissions, credentials handling, process ownership, or any runtime behavior.

### Cross-port to openjd-rs

This package is being migrated to Rust in [`openjd-rs/crates/openjd-sessions`](https://github.com/OpenJobDescription/openjd-rs/tree/main/crates/openjd-sessions).
Behavioral changes made here should be replicated there to keep the two
implementations in sync until the migration is complete.

- [x] This change does not affect runtime behavior (docs / tests / tooling only), **or**
- [ ] A matching change has been opened in `openjd-rs` (link the PR here): *<insert link>*, **or**
- [ ] A tracking issue has been filed in `openjd-rs` to port this change (link here): *<insert link>*, **or**
- [ ] Cross-porting is not applicable for this change because: *<reason>*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
