### PR TITLE
feat: enable Claude PR review

### DIFF
--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -1,0 +1,56 @@
+# Stage 2 caller for the Claude PR-review integration: the "review" workflow.
+#
+# Triggered by completion of the Stage-1 "collect" workflow. Because the trigger
+# is workflow_run, GitHub runs this file from the default branch (never a fork's
+# copy) and with this repo's secrets -- so a fork PR cannot alter the review
+# behavior, permissions, or credential setup.
+#
+# All the review logic (Bedrock auth, the pinned action, the restricted tool
+# surface, the read-only PR-head checkout, and per-run limits) lives in the
+# reusable workflow in aws-deadline/.github. This caller only forwards the
+# workflow_run identifiers and the role-ARN secret.
+name: Claude PR Review
+
+on:
+  workflow_run:
+    workflows: ["Claude PR Review (collect)"]
+    types:
+      - completed
+
+# Cancel a superseded review when the PR is pushed again, keyed on the trusted head repo + branch from the workflow_run payload (no pull_request.number here).
+concurrency:
+  group: claude-pr-review-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+# Least privilege. The reusable workflow re-declares the same scopes on its job;
+# these are the ceiling for the called workflow.
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  review:
+    # Only run if Stage 1 succeeded, and only for runs triggered by a
+    # pull_request. The collect workflow listens on pull_request alone today, but
+    # gating on the event here is defense in depth: if another trigger
+    # (workflow_dispatch, schedule, ...) is ever added to the collect workflow,
+    # this prevents a review from firing -- with the base repo's secrets and a
+    # fork-controlled head_sha -- from a non-PR context.
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    uses: aws-deadline/.github/.github/workflows/reusable_claude_pr_review.yml@mainline
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    with:
+      # Head repo and head SHA come from the server-populated workflow_run event
+      # payload, which a fork cannot forge. The review stage resolves the PR
+      # number and base SHA from these, so nothing fork-controlled is trusted.
+      head_repository: ${{ github.event.workflow_run.head_repository.full_name }}
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+    secrets:
+      # OIDC role that can mint a Bedrock bearer token.
+      bedrock_role_arn: ${{ secrets.AWS_CLAUDE_PR_REVIEW_ROLE }}

--- a/.github/workflows/claude_pr_review_collect.yml
+++ b/.github/workflows/claude_pr_review_collect.yml
@@ -1,0 +1,32 @@
+# Stage 1 trigger for the Claude PR-review integration: the "collect" workflow.
+#
+# Runs on pull_request. For PRs from forks GitHub provides no secrets and a
+# read-only GITHUB_TOKEN. This stage does no work and records nothing -- it
+# exists only so that its completion fires the workflow_run event that starts
+# the review stage (claude_pr_review.yml).
+#
+# Crucially, this stage produces NO data that the review stage trusts. The
+# review stage derives the PR number, head SHA, and base SHA entirely from the
+# server-populated workflow_run event payload (which a fork cannot forge), so a
+# fork's copy of this file cannot influence what gets reviewed or where comments
+# are posted.
+#
+# This is a thin caller -- the (now no-op) collect job lives in the reusable
+# workflow in aws-deadline/.github.
+name: Claude PR Review (collect)
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# Cancel an in-flight collect run when the PR is updated again.
+concurrency:
+  group: claude-pr-review-collect-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# No permissions needed: this stage only exists to fire the workflow_run event.
+permissions: {}
+
+jobs:
+  collect:
+    uses: aws-deadline/.github/.github/workflows/reusable_claude_pr_review_collect.yml@mainline


### PR DESCRIPTION
Enables the automated, advisory Claude PR-review integration in this repository, matching what is already enabled across the AWS Deadline Cloud repos (e.g. [aws-deadline/deadline-cloud (#1195)](https://github.com/aws-deadline/deadline-cloud/pull/1195)).

## What this adds

Two thin caller workflows under `.github/workflows/`:

- **`claude_pr_review_collect.yml`** — Stage 1. Runs on `pull_request` (opened, synchronize). It does no work and records nothing; it exists only so its completion fires the `workflow_run` event that starts the review stage. It produces no data the review stage trusts.
- **`claude_pr_review.yml`** — Stage 2. Triggered by the collect workflow's completion via `workflow_run`, so GitHub runs it from the default branch with this repo's secrets — a fork PR cannot alter the review behavior, permissions, or credential setup. Derives the PR number, head SHA, and base SHA from the server-populated `workflow_run` payload (which a fork cannot forge).

All the actual review logic — Bedrock authentication, the SHA-pinned action, the restricted read-only tool surface, the read-only PR-head checkout, and per-run turn/token/time limits — lives in the shared reusable workflow at `aws-deadline/.github/.github/workflows/reusable_claude_pr_review.yml@mainline`. These files are thin callers that forward the `workflow_run` identifiers and the `AWS_CLAUDE_PR_REVIEW_ROLE` secret.

## Prerequisite

The `AWS_CLAUDE_PR_REVIEW_ROLE` secret (the OIDC role that can mint a Bedrock bearer token) must be configured for this repository for the review stage to run.