### PR TITLE
fix: poll through CANCELING state to deliver terminal callback

### DIFF
--- a/src/openjd/sessions/_v1/_session.py
+++ b/src/openjd/sessions/_v1/_session.py
@@ -186,7 +186,7 @@ class Session:
             while True:
                 state = self._rust_session.state
                 status = self._rust_session.action_status
-                if state == SessionState.RUNNING:
+                if state in (SessionState.RUNNING, SessionState.CANCELING):
                     if status is not None and self._callback:
                         if not reported_running:
                             # Defensive: the synchronous initial callback
@@ -201,7 +201,7 @@ class Session:
                             self._callback(self._session_id, status)
                     time.sleep(0.05)
                     continue
-                # Not RUNNING anymore — action is done.
+                # Not RUNNING/CANCELING anymore — action is done.
                 # If we never saw RUNNING (e.g. Rust finished before we got here),
                 # still report the RUNNING transition first, so the agent state
                 # machine sees Start → End in order.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `_poll_for_completion` thread exited the polling loop as soon as the session state transitioned away from RUNNING. When `cancel_action()` is called, the pyo3 binding immediately sets the snapshot state to CANCELING — causing the poller to exit before the subprocess has been killed and before the Rust callback delivers the terminal CANCELED ActionStatus.

The result: the worker agent never receives the CANCELED callback, leaving the action stuck in CANCELING forever from the service perspective.

### What was the solution? (How)

Treat CANCELING as an in-progress state (like RUNNING) and continue polling. The poller now exits only when the state reaches READY or READY_ENDING, at which point `action_status` contains the correct terminal state.

### What is the impact of this change?

Actions that are cancelled mid-execution now correctly transition through CANCELING → CANCELED instead of hanging in CANCELING forever.

### How was this change tested?

- Validated end-to-end via the AWS Deadline Cloud worker agent e2e suite (cancel scenarios all passing; full Linux suite 48/49 with the one failure unrelated to this change).

### Was this change documented?

- Comment in code updated to reflect the new RUNNING/CANCELING loop condition.

### Is this a breaking change?

No. This is a bugfix to internal polling behavior; the public API is unchanged.

### Does this change impact security?

No.

### Cross-port to openjd-rs

- [x] Cross-porting is not applicable for this change because: this fix is in the Python `_v1` polling layer that bridges the Rust session to the Python callback. The Rust session itself already handles cancellation correctly — the bug was only in the Python polling shim that sits between the two.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*