### PR TITLE
fix: decode subprocess output with errors=backslashreplace

### DIFF
--- a/src/openjd/sessions/_subprocess.py
+++ b/src/openjd/sessions/_subprocess.py
@@ -462,6 +462,15 @@ class LoggingSubprocess(object):
                 stdout=PIPE,
                 stderr=STDOUT,
                 encoding=self._encoding,
+                # A subprocess (e.g. a Windows DCC application writing cp1252) can emit
+                # bytes that are not valid in the configured encoding. With the default
+                # strict error handling a single undecodable byte raises
+                # UnicodeDecodeError in the stdout reader thread, killing it; all
+                # subsequent output from the subprocess is then silently lost. Escaping
+                # undecodable bytes (e.g. b"\x97" -> "\\x97") keeps the reader alive
+                # while preserving the original byte values in the logs, which helps
+                # identify the codepage the subprocess is emitting.
+                errors="backslashreplace",
                 start_new_session=True,
                 cwd=self._working_dir,
             )

--- a/test/openjd/sessions_v0/test_subprocess.py
+++ b/test/openjd/sessions_v0/test_subprocess.py
@@ -7,6 +7,7 @@ import tempfile
 import time
 import os
 import getpass
+from base64 import b64encode
 from concurrent.futures import ThreadPoolExecutor, wait
 from logging.handlers import QueueHandler
 from pathlib import Path
@@ -124,6 +125,203 @@ class TestLoggingSubprocessSameUser:
         assert message_queue.qsize() > 0
         messages = collect_queue_messages(message_queue)
         assert message in messages
+
+    def test_non_utf8_output_does_not_kill_reader(
+        self,
+        message_queue: SimpleQueue,
+        queue_handler: QueueHandler,
+        python_exe: str,
+    ) -> None:
+        # A child process that emits bytes that are not valid UTF-8 (e.g. a Windows
+        # DCC application writing cp1252 to stdout) must not crash the stdout reader
+        # thread. If the reader dies, all subsequent output is silently lost.
+        # Regression test for the customer-reported UnicodeDecodeError on byte 0x97
+        # (cp1252 em dash from Unreal Engine).
+
+        # GIVEN
+        logger = build_logger(queue_handler)
+        script = (
+            "import sys; "
+            "sys.stdout.buffer.write(b'before\\n'); "
+            "sys.stdout.buffer.flush(); "
+            "sys.stdout.buffer.write(b'bad \\x97 byte\\n'); "
+            "sys.stdout.buffer.flush(); "
+            "sys.stdout.buffer.write(b'after\\n'); "
+            "sys.stdout.buffer.flush()"
+        )
+        subproc = LoggingSubprocess(
+            logger=logger,
+            args=[python_exe, "-c", script],
+        )
+
+        # WHEN
+        subproc.run()
+
+        # THEN
+        assert subproc.exit_code == 0
+        messages = collect_queue_messages(message_queue)
+        assert "before" in messages
+        # "after" is only logged if the reader thread survived the undecodable byte.
+        assert "after" in messages
+
+    @pytest.mark.parametrize(
+        argnames=("raw_bytes", "expected_escaped"),
+        argvalues=[
+            # 0x97 is the em dash in cp1252 — the exact byte from the customer report
+            # (Unreal Engine on Windows writing cp1252 to stdout).
+            (b"bad \x97 byte", "bad \\x97 byte"),
+            # 0xff is never valid anywhere in UTF-8.
+            (b"bad \xff byte", "bad \\xff byte"),
+            # Consecutive invalid bytes must each be escaped separately.
+            (b"bad \xc7\xff bytes", "bad \\xc7\\xff bytes"),
+            # cp1252-encoded text run — an invalid two-byte sequence in UTF-8.
+            (b"bad \xc7\xe9 text", "bad \\xc7\\xe9 text"),
+            # A truncated UTF-8 multi-byte sequence (0xe4 0xbd is an incomplete
+            # 3-byte sequence) followed by valid ASCII.
+            (b"truncated \xe4\xbd then ok", "truncated \\xe4\\xbd then ok"),
+        ],
+        ids=[
+            "cp1252-em-dash",
+            "invalid-byte",
+            "consecutive-invalid",
+            "cp1252-text",
+            "truncated-utf8",
+        ],
+    )
+    def test_non_utf8_output_is_escaped(
+        self,
+        message_queue: SimpleQueue,
+        queue_handler: QueueHandler,
+        python_exe: str,
+        raw_bytes: bytes,
+        expected_escaped: str,
+    ) -> None:
+        # Undecodable bytes in subprocess output must be escaped with backslashreplace
+        # (e.g. b"\x97" -> "\\x97") so the original byte values are preserved in the
+        # logs. Preserving the byte values (rather than collapsing to U+FFFD) helps
+        # identify the codepage the subprocess is emitting.
+
+        # GIVEN
+        logger = build_logger(queue_handler)
+        # The trailing "!" proves the full line was logged, not truncated at the bad
+        # byte; the newline terminates the line for the reader's readline().
+        payload = raw_bytes + b"!\n"
+        script = (
+            "import sys; " f"sys.stdout.buffer.write({payload!r}); " "sys.stdout.buffer.flush()"
+        )
+        subproc = LoggingSubprocess(
+            logger=logger,
+            args=[python_exe, "-c", script],
+        )
+
+        # WHEN
+        subproc.run()
+
+        # THEN
+        assert subproc.exit_code == 0
+        messages = collect_queue_messages(message_queue)
+        # The trailing "!" proves the full line was logged, not truncated at the bad byte.
+        assert expected_escaped + "!" in messages
+        # The replacement character must not appear; the byte value must be preserved.
+        replaced = [m for m in messages if "\ufffd" in m]
+        assert not replaced
+
+    def test_valid_utf8_is_not_escaped(
+        self,
+        message_queue: SimpleQueue,
+        queue_handler: QueueHandler,
+        python_exe: str,
+    ) -> None:
+        # Valid multi-byte UTF-8 sequences must pass through unmodified — escaping
+        # applies only to genuinely invalid sequences.
+
+        # GIVEN
+        logger = build_logger(queue_handler)
+        message = "héllo wörld Ç 星期五"
+        # Pass the payload base64-encoded so the "Running command" log line does not
+        # itself contain backslash-x escape sequences (from the bytes repr), which
+        # would defeat the "no escapes appeared" assertion below.
+        payload_b64 = b64encode(message.encode("utf-8")).decode("ascii")
+        script = (
+            "import sys, base64; "
+            f"sys.stdout.buffer.write(base64.b64decode('{payload_b64}') + b'\\n'); "
+            "sys.stdout.buffer.flush()"
+        )
+        subproc = LoggingSubprocess(
+            logger=logger,
+            args=[python_exe, "-c", script],
+        )
+
+        # WHEN
+        subproc.run()
+
+        # THEN
+        assert subproc.exit_code == 0
+        messages = collect_queue_messages(message_queue)
+        assert message in messages
+        # Scope the escape sweep to subprocess output lines. The "Running command"
+        # log line contains the interpreter path, which on Windows contains
+        # backslashes that could false-positive this assertion.
+        output_messages = [m for m in messages if not m.startswith("Running command")]
+        escaped = [m for m in output_messages if "\\x" in m]
+        assert not escaped
+        replaced = [m for m in output_messages if "\ufffd" in m]
+        assert not replaced
+
+    def test_non_utf8_output_is_escaped_with_non_default_encoding(
+        self,
+        message_queue: SimpleQueue,
+        queue_handler: QueueHandler,
+        python_exe: str,
+    ) -> None:
+        # The escape behavior must hold for any configured encoding, not only the
+        # utf-8 default: bytes that are invalid in that encoding are escaped, and
+        # bytes that are valid in it decode normally.
+
+        # GIVEN
+        logger = build_logger(queue_handler)
+        # 0x81 is undefined in cp1252 and must be escaped; 0x97 is the em dash in
+        # cp1252 and must decode to U+2014.
+        payload = b"undef \x81 byte, dash \x97 ok!\n"
+        script = (
+            "import sys; " f"sys.stdout.buffer.write({payload!r}); " "sys.stdout.buffer.flush()"
+        )
+        subproc = LoggingSubprocess(
+            logger=logger,
+            args=[python_exe, "-c", script],
+            encoding="cp1252",
+        )
+
+        # WHEN
+        subproc.run()
+
+        # THEN
+        assert subproc.exit_code == 0
+        messages = collect_queue_messages(message_queue)
+        assert "undef \\x81 byte, dash \u2014 ok!" in messages
+
+    def test_popen_uses_backslashreplace_error_handler(self) -> None:
+        # Pin the errors= kwarg on the Popen construction itself. This protects all
+        # construction paths that reuse the shared popen_args dict (same-user Popen,
+        # the posix sudo path, and PopenWindowsAsUser, which CI integration tests
+        # cannot all reach) against a refactor that moves or drops the kwarg.
+
+        # GIVEN
+        logger = MagicMock()
+        subproc = LoggingSubprocess(
+            logger=logger,
+            args=[sys.executable, "-c", "pass"],
+        )
+
+        # WHEN
+        with patch.object(subprocess_impl_mod, "Popen") as mock_popen:
+            subproc._start_subprocess()
+
+        # THEN
+        mock_popen.assert_called_once()
+        kwargs = mock_popen.call_args.kwargs
+        assert kwargs["errors"] == "backslashreplace"
+        assert kwargs["encoding"] == "utf-8"
 
     def test_cannot_run(self, message_queue: SimpleQueue, queue_handler: QueueHandler) -> None:
         # Make sure that we log a message, and don't blow up when we cannot


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`LoggingSubprocess` creates its `Popen` with `encoding="utf-8"` but no `errors=` parameter, so decoding defaults to `errors="strict"`. A single byte of subprocess output that is not valid UTF-8 raises `UnicodeDecodeError` inside the `_enqueue_stdout` reader thread, which has no exception handling:

```
File "openjd/sessions/_subprocess.py", line 371, in _enqueue_stdout
    for line in iter(_stream_readline_max_length, ""):
  File "openjd/sessions/_subprocess.py", line 362, in _stream_readline_max_length
    return stream.readline(LOG_LINE_MAX_LENGTH)
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x97 in position 33: invalid start byte
```

The thread dies silently and all subsequent stdout from the subprocess is lost, which can mask real errors from the job. This was reported from a production Windows customer-managed fleet where Unreal Engine writes cp1252 to stdout (byte `0x97`, the cp1252 em dash). Any Windows DCC application using the system code page (Unreal, 3ds Max, Houdini) can trigger it.

openjd-adaptor-runtime-for-python had the identical defect in its own `LoggingSubprocess` and fixed it in #275 / #277. This PR ports that fix.

### What was the solution? (How)

Pass `errors="backslashreplace"` to the `Popen`. Undecodable bytes are escaped (e.g. `b"\x97"` becomes the text `\x97`) instead of raising. The reader thread stays alive, no output is lost, and the original byte values are preserved in the logs, which helps identify the codepage the subprocess is emitting (`backslashreplace` rather than `replace`, matching the adaptor runtime's follow-up in #277).

The shared `popen_args` dict is used by all three construction paths (same-user `Popen`, the posix sudo path, and `PopenWindowsAsUser`, which forwards kwargs to `Popen.__init__`), so all of them get the fix.

### What is the impact of this change?

- Jobs whose processes emit non-UTF-8 output no longer silently lose all log output after the first bad byte.
- Log content changes for such processes: previously the line with the bad byte and everything after it was dropped; now every line is logged, with invalid bytes escaped as `\xNN`.
- Valid UTF-8 output is unaffected (covered by a regression test).

### How was this change tested?

Test-first: the regression tests were written before the fix and reproduce the exact customer stack trace against the unfixed code (6 of 7 fail before the fix; the valid-UTF-8 negative control passes, as expected).

New tests in `test/openjd/sessions_v0/test_subprocess.py`:

- `test_non_utf8_output_does_not_kill_reader` — reader thread survives a bad byte; output written after it is still captured.
- `test_non_utf8_output_is_escaped` (5 cases) — exact escape formatting for the customer's cp1252 em dash, an always-invalid byte, consecutive invalid bytes, cp1252 text runs, and a truncated UTF-8 multi-byte sequence; asserts U+FFFD does not appear.
- `test_valid_utf8_is_not_escaped` — valid multi-byte UTF-8 passes through unmodified (guards against over-escaping).
- `test_non_utf8_output_is_escaped_with_non_default_encoding` — the escape behavior holds for a configured `encoding="cp1252"`: bytes undefined in cp1252 are escaped, valid cp1252 decodes normally.
- `test_popen_uses_backslashreplace_error_handler` — pins the `errors=` kwarg on the `Popen` construction shared by the sudo and Windows-as-user paths, which platform CI cannot all reach.

Every test was mutation-checked. Four mutants were applied to `_subprocess.py` and each is caught by at least one test, with the full suite green when restored:

| Mutant | Caught by |
|---|---|
| remove `errors=` (revert the fix) | 8 tests, incl. reader-survival |
| `errors="replace"` | 7 tests (byte values must be preserved, not U+FFFD) |
| `errors="ignore"` | 7 tests (bytes must not be dropped) |
| force `encoding="ascii"` | 3 tests, incl. the valid-UTF-8 negative control |

Full suite: 911 passed on macOS (the 8 failures on my machine are pre-existing and reproduce identically on unmodified mainline; they need a bare `python` on PATH or target-user env vars). `black --check`, `ruff check`, and `mypy` all pass.

### Was this change documented?

Yes: the new `errors=` line carries a comment explaining the failure mode it prevents and why `backslashreplace` was chosen; each test documents what it pins.

### Is this a breaking change?

No. The public API is unchanged. The only observable difference is that output which previously crashed the log reader (and was silently dropped) is now logged with invalid bytes escaped.

### Does this change impact security?

No new files, directories, or permissions. Log content can now include escaped byte values that were previously dropped; these come from the same process output that is already logged.

### Cross-port to openjd-rs

- [x] A tracking issue has been filed in `openjd-rs` to port this change (link here): https://github.com/OpenJobDescription/openjd-rs/issues/296

The Rust engine reads raw bytes and decodes with `String::from_utf8_lossy`, so it does not have the crash, but it collapses undecodable bytes to U+FFFD instead of preserving them; the issue tracks aligning it with the backslashreplace semantics.

----
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
